### PR TITLE
fix: don't crash-exit when the UDP telemetry port is busy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,7 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 
 | File | Responsibility |
 |---|---|
-| [app/main.py](app/main.py) | Wiring: lifespan creates Store/Hub/SessionTracker, binds the UDP endpoint, runs a 1 s watchdog that closes sessions on silence. `no-cache` middleware for non-`/api` paths (keep it — stale-JS bug shipped once). Serves `app/static/` at `/`. |
+| [app/main.py](app/main.py) | Wiring: lifespan creates Store/Hub/SessionTracker, binds the UDP endpoint (a busy port is caught, logged, and surfaced via `app.state.udp_error` / `/api/status` rather than crash-exiting — the dashboard keeps serving), runs a 1 s watchdog that closes sessions on silence. `no-cache` middleware for non-`/api` paths (keep it — stale-JS bug shipped once). Serves `app/static/` at `/`. |
 | [app/telemetry/packet.py](app/telemetry/packet.py) | 324-byte Data Out struct: `parse()`, `pack()` (simulator/tests), `empty_fields()`, `FIELDS` name/count table. Self-test via `python app/telemetry/packet.py`. |
 | [app/telemetry/listener.py](app/telemetry/listener.py) | `asyncio.DatagramProtocol`: counts packets, warns once on wrong size (hex dump), parses, feeds tracker, publishes frame+extras to hub. Recorder exceptions never kill the stream. |
 | [app/telemetry/hub.py](app/telemetry/hub.py) | Fan-out to WebSocket subscriber queues (drop-oldest on slow clients) + stream stats used by `/api/status`. |
@@ -61,7 +61,7 @@ each runs on every startup inside try/except (existing-column errors swallowed).
 
 | Endpoint | Notes |
 |---|---|
-| `GET /status` | Packet counters, last-packet age/size, active session, session best. First stop when "nothing works". |
+| `GET /status` | Packet counters, last-packet age/size, active session, session best, and `udp_error` (non-null when the UDP port could not be bound). First stop when "nothing works". |
 | `GET /sessions` | List with route/car-name joins, lap counts, best lap. |
 | `PATCH /sessions/{id}` | `name`, `conditions` (`dry/wet/snow`, `""` clears), `track_type` (`road/street/touge/dirt/cross/drag/wtc`, `""` clears). |
 | `POST /sessions/{id}/reprocess` | Rebuild laps from stored frames (async def — event-loop writes). 409 while recording. |

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -83,6 +83,7 @@ async def status(request: Request):
     now = time.time()
     return {
         "udp_port": request.app.state.udp_port,
+        "udp_error": getattr(request.app.state, "udp_error", None),
         "packets_total": hub.packets_total,
         "bad_packets": hub.bad_packets,
         "last_packet_age": None if hub.last_packet_time is None else round(now - hub.last_packet_time, 3),

--- a/app/main.py
+++ b/app/main.py
@@ -45,17 +45,38 @@ async def lifespan(app: FastAPI):
     app.state.store, app.state.hub, app.state.tracker = store, hub, tracker
     app.state.udp_port = udp_port
 
+    app.state.udp_error = None
     loop = asyncio.get_running_loop()
-    transport, _ = await loop.create_datagram_endpoint(
-        lambda: TelemetryProtocol(hub, tracker), local_addr=("0.0.0.0", udp_port)
-    )
-    log.info("Listening for FH6 Data Out on UDP %d; dashboard on HTTP 8000", udp_port)
+    transport = None
+    try:
+        transport, _ = await loop.create_datagram_endpoint(
+            lambda: TelemetryProtocol(hub, tracker), local_addr=("0.0.0.0", udp_port)
+        )
+        log.info("Listening for FH6 Data Out on UDP %d; dashboard on HTTP 8000", udp_port)
+    except OSError as exc:
+        # Port already taken (another telemetry tool, or a second LapScope
+        # window). Don't crash-exit — that slams the console shut on a
+        # double-clicked exe before the user can read anything. Keep the
+        # dashboard serving (past-session analysis still works) and surface an
+        # actionable message here and in /api/status.
+        app.state.udp_error = (
+            f"UDP port {udp_port} is already in use - another program (or a second "
+            "LapScope window) has it. Close that program, or set TELEMETRY_UDP_PORT to "
+            "a free port, then restart LapScope."
+        )
+        log.error(
+            "Could not bind UDP telemetry port %d (%s). %s "
+            "The dashboard is still available on HTTP 8000, but no live telemetry "
+            "will arrive until the port is free.",
+            udp_port, exc, app.state.udp_error,
+        )
     watchdog = asyncio.create_task(_watchdog(tracker))
 
     yield
 
     watchdog.cancel()
-    transport.close()
+    if transport is not None:
+        transport.close()
     tracker.shutdown(time.time())
     store.close()
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -421,6 +421,15 @@ main.grid .lap-grid { margin-bottom: auto; }
 }
 .setup-lines { line-height: 2; }
 .overlay .stat { color: var(--muted); font-size: 0.85rem; margin-top: 16px; }
+.overlay .stat.error {
+  color: var(--bad);
+  font-size: 0.95rem;
+  font-weight: 600;
+  max-width: 42ch;
+  border: 1px solid #5b2a2a;
+  border-radius: 8px;
+  padding: 10px 14px;
+}
 
 .pulse-ring { display: flex; justify-content: center; }
 .pulse-ring i {

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -137,11 +137,18 @@ async function pollStatus() {
   try {
     const st = await (await fetch("/api/status")).json();
     $("nd-port").textContent = st.udp_port;
-    $("nd-stat").textContent =
-      st.packets_total === 0
-        ? `server: no packets received yet on UDP ${st.udp_port}` +
-          (st.bad_packets ? ` (${st.bad_packets} wrong-size packets!)` : "")
-        : `server: ${st.packets_total} packets received, last ${st.last_packet_age}s ago`;
+    const stat = $("nd-stat");
+    if (st.udp_error) {
+      stat.textContent = st.udp_error;
+      stat.classList.add("error");
+    } else {
+      stat.classList.remove("error");
+      stat.textContent =
+        st.packets_total === 0
+          ? `server: no packets received yet on UDP ${st.udp_port}` +
+            (st.bad_packets ? ` (${st.bad_packets} wrong-size packets!)` : "")
+          : `server: ${st.packets_total} packets received, last ${st.last_packet_age}s ago`;
+    }
   } catch { /* server briefly unavailable */ }
 }
 setInterval(() => { if (!$("nodata").classList.contains("hidden")) pollStatus(); }, 2000);


### PR DESCRIPTION
## Summary

Fixes the packaged exe crashing on startup when its UDP telemetry port is already in use.

A double-clicked `LapScope.exe` whose UDP port (9999) was taken by another program or a second LapScope window died with an `OSError` traceback and closed its console instantly, so the user saw only a flash and no explanation.

- **`app/main.py`**: catch the busy-port `OSError` around `create_datagram_endpoint`; log a clear, actionable message and keep the HTTP dashboard serving (past-session analysis still works) instead of crash-exiting. The window stays open so the message is readable. Guarded the shutdown `transport.close()`.
- **`app/api/routes.py`**: expose `udp_error` in `GET /api/status`.
- **`dashboard.js` + `style.css`**: surface `udp_error` prominently in the "Waiting for telemetry" overlay, so non-technical users who never look at the console still get the fix instructions.
- **`ARCHITECTURE.md`**: document the behavior and the new status field.

## Test plan

- [x] `ruff check .` and `pytest -q` (15 passed) green.
- [x] Ran the app from source with UDP 9999 busy: server stays up (`/api/status` -> 200 with `udp_error`, `/` -> 200); log shows one clean `ERROR` line then `Application startup complete` (no traceback, no exit).
- [x] Rebuilt `dist/LapScope/LapScope.exe` and launched it on the busy port: HTTP up, `/api/status` returns the `udp_error` message (ASCII, no mojibake).
- [ ] Confirm CI is green on this PR.

## Notes

- Draft: opening for CI + review.
- The fix stops the crash; live telemetry still can't arrive while another program holds the port. Recovery is to free the port or set `TELEMETRY_UDP_PORT` (and FH6's Data Out port) to a free one.
- After merge, cut a new patch tag (e.g. `v0.1.1`) to trigger the release workflow and publish a fixed exe.
