### PR TITLE
docs: repo hygiene files + document branch protection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Something isn't working the way it should.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Please search [existing issues](../issues) first.
+        If the problem is **an event/lap not being recorded correctly**, use the
+        "Unrecognized / mis-recorded event capture" template instead — it asks
+        for the extra data we need.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start LapScope ...
+        2. Drive / run `python tools/simulator.py ...`
+        3. See ...
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How are you running LapScope?
+      options:
+        - Windows .exe (release build)
+        - Docker
+        - From source (python)
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: LapScope version
+      description: From the release zip name, or the git commit if running from source.
+      placeholder: "e.g. v0.3.1 / commit 47ef0c7"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / environment
+      placeholder: "e.g. Windows 11 26200, or Docker on Ubuntu 24.04"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / console output
+      description: >
+        Paste any relevant output from the console window (exe) or
+        `docker compose logs`. Also useful: what
+        http://localhost:8000/api/status shows.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: This is a bug, not an unrecognized-event capture (that has its own template).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/darcane/LapScope/discussions
+    about: Ask a question or discuss an idea before filing an issue.
+  - name: Troubleshooting (no packets, setup)
+    url: https://github.com/darcane/LapScope/wiki
+    about: Setup, in-game Data Out settings, and the UWP-loopback / Docker port fixes live in the README and Wiki.
+  - name: Report a security issue (private)
+    url: https://github.com/darcane/LapScope/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new feature or improvement.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Please check [existing issues](../issues) and
+        [TODO.md](../blob/main/TODO.md) first — it may already be planned.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point. "As a driver, I want … so that …".
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see. Sketches / mockups welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, if any.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and TODO.md and this isn't a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/unrecognized_event.yml
+++ b/.github/ISSUE_TEMPLATE/unrecognized_event.yml
@@ -1,0 +1,94 @@
+name: Unrecognized / mis-recorded event capture
+description: An event or lap wasn't recorded, was discarded, or was timed wrong.
+title: "capture: "
+labels: ["event-detection", "capture"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **This is the most valuable kind of report.** FH6 sends no explicit
+        event boundaries, so LapScope infers them — and it can only learn a new
+        event type from a real capture. Please help it self-heal.
+
+        **How to capture a discarded session:**
+        1. Set `LS_KEEP_DISCARDED=1` (Docker: it's passed through from the
+           environment or a repo-root `.env`; exe/source: set the env var before
+           launching) so the session is kept instead of discarded.
+        2. Drive/replay the event that misbehaves.
+        3. Find its id and dump its signal transitions:
+           ```
+           python tools/inspect_session.py --list
+           python tools/inspect_session.py <id>
+           ```
+        4. Paste the `inspect_session` output below. If you can, attach (or
+           offer) the `data/telemetry.db` — the raw frames let us reproduce and
+           add a test.
+
+        More on the workflow: the README "Troubleshooting" section and the Wiki.
+  - type: dropdown
+    id: event-type
+    attributes:
+      label: What kind of event was it?
+      options:
+        - Circuit race
+        - Rivals
+        - Sprint / point-to-point
+        - Dirt / cross-country
+        - Touge
+        - Drag
+        - World Time Attack
+        - Free roam
+        - Other / not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: symptom
+    attributes:
+      label: What went wrong?
+      options:
+        - The session was discarded (didn't show up at all)
+        - A lap/run was missing
+        - A phantom / extra lap was recorded
+        - A lap/run time was wrong
+        - A dirty-lap flag was wrong (missing or false 💥 contact / ⏪ rewind)
+        - Wrong route / condition / metadata
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: e.g. "one run of ~92 s", "3 laps, last one timed".
+    validations:
+      required: true
+  - type: textarea
+    id: inspect
+    attributes:
+      label: inspect_session output
+      description: Output of `python tools/inspect_session.py <id>` for the affected session.
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: LapScope version
+      placeholder: "e.g. v0.3.1 / commit 47ef0c7"
+    validations:
+      required: true
+  - type: textarea
+    id: db-offer
+    attributes:
+      label: Raw capture (telemetry.db)
+      description: >
+        The raw frames are what let us add a regression test. Can you share the
+        session's `data/telemetry.db`? Say yes/no here; a maintainer will follow
+        up on how to send it if needed.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I captured this with `LS_KEEP_DISCARDED=1` (or the session was kept anyway) and included the inspect_session output.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+  Thanks for contributing to LapScope!
+  Because we squash-merge, this PR's TITLE becomes the commit on main —
+  make it a clear, imperative, prefixed summary, e.g.
+  "fix: don't crash-exit when the UDP telemetry port is busy".
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? Link any related issue: "Closes #123". -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Event-detection change (recorder / `laps.py`)
+- [ ] Docs only
+- [ ] Refactor / chore
+
+## How was it tested?
+
+<!--
+  Which simulator command(s) and/or tests cover this?
+  e.g. `python tools/simulator.py --race 3 --duration 200`
+-->
+
+## Checklist
+
+- [ ] Branched off `main` as `feat/…` or `fix/…`.
+- [ ] `ruff check .` passes.
+- [ ] `python app/telemetry/packet.py` (packet self-test) passes.
+- [ ] `pytest -q` passes.
+- [ ] Docs updated where relevant (AGENTS.md for detection changes,
+      ARCHITECTURE.md for structural/schema/API changes, README.md for
+      user-visible features).
+- [ ] For a new detection scenario: added a `tools/simulator.py` flag **and** a
+      matching assertion in `tests/test_scenarios.py`.
+- [ ] Cross-file invariants kept in sync (see ARCHITECTURE.md "Cross-file
+      invariants").

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting the
+maintainer, [@darcane](https://github.com/darcane). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to LapScope
+
+Thanks for wanting to help! LapScope is a self-hosted Forza Horizon 6 telemetry
+dashboard and lap analyzer. Issues and pull requests are welcome — especially
+**captures of event types that aren't detected yet** and **car-ordinal
+additions**.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Where to start
+
+- **Found a bug?** Open a [bug report](../../issues/new?template=bug_report.yml).
+- **An event type isn't recorded correctly?** This is the most valuable kind of
+  report — use the
+  [unrecognized event capture](../../issues/new?template=unrecognized_event.yml)
+  template and follow the capture workflow it links to.
+- **Have an idea?** Open a
+  [feature request](../../issues/new?template=feature_request.yml).
+- **Want to code?** Comment on an existing issue so we don't duplicate work, then
+  follow the workflow below.
+
+## Project layout & docs
+
+Read these before making non-trivial changes:
+
+- **[AGENTS.md](AGENTS.md)** — dev workflow, the hard-won FH6 packet facts, and
+  the event-detection model. The *why* behind the recorder.
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — what lives where: file
+  responsibilities, data flow, DB schema, API surface, and the cross-file
+  invariants that must stay in sync.
+- **[README.md](README.md)** — user-facing setup, in-game settings, and
+  troubleshooting.
+
+## Development setup
+
+You don't need the game or a real Xbox to work on most of LapScope — a built-in
+simulator replays realistic telemetry.
+
+```bash
+# 1. Install runtime + dev tooling
+pip install -r requirements.txt -r requirements-dev.txt
+
+# 2. Run the app (Docker is the reference environment)
+docker compose up --build -d          # http://localhost:8000
+
+# 3. Feed it synthetic telemetry (no game needed)
+python tools/simulator.py --race 3 --duration 200
+```
+
+> Static files are **baked into the image** — any change under `app/` needs a
+> `docker compose build` + restart to take effect. There is no bind mount for
+> code.
+
+## Making a change
+
+We use a **branch → PR → squash-merge** workflow. `main` is protected; nothing
+lands on it except a green, reviewed PR.
+
+1. **Cut a branch off `main`.** Name it `feat/<short-desc>` for features or
+   `fix/<short-desc>` for fixes.
+2. **Make your change**, keeping the docs in step:
+   - a detection change usually touches the AGENTS.md model section,
+   - a new endpoint/table belongs in ARCHITECTURE.md,
+   - a new user-visible feature belongs in the README.
+3. **Add or update tests.** New detection behavior needs a scenario in
+   `tools/simulator.py` and a matching headless assertion in
+   `tests/test_scenarios.py`.
+4. **Run the checks locally** (CI runs the exact same ones):
+
+   ```bash
+   ruff check .
+   python app/telemetry/packet.py     # packet round-trip self-test
+   pytest -q
+   ```
+
+5. **Open a pull request** against `main` and fill in the template. Keep PRs
+   focused — one logical change per PR is much easier to review.
+
+### Commit & PR style
+
+- Write imperative, prefixed commit subjects matching the existing history:
+  `feat:`, `fix:`, `docs:`, `test:`, `chore:` (e.g.
+  `fix: don't crash-exit when the UDP telemetry port is busy`).
+- Because we **squash-merge**, the *PR title* becomes the commit on `main` — make
+  it a good one-line summary in the same style.
+- Don't force-push to `main` (it's protected anyway). Never push directly to
+  `main`.
+
+## Branch protection rules (enforced on `main`)
+
+These are enforced in the GitHub repo settings; contributors just need to know
+what they imply:
+
+- **No direct pushes to `main`** — all changes go through a pull request.
+- **A pull request is required**, with at least **one approving review** and all
+  review conversations resolved before merge.
+- **Status checks must pass** before merging — the required check is **`test`**
+  (the CI workflow: `ruff`, the `packet.py` self-test, and `pytest`).
+- **Branches must be up to date with `main`** before merging (so CI runs against
+  the final merged state).
+- **Squash and merge is the only allowed merge method** — merge commits and
+  rebase merges are disabled, so `main` stays one commit per PR.
+
+## Reporting security issues
+
+Please **do not** open a public issue for a security problem. Report it privately
+via GitHub's [security advisory form](../../security/advisories/new) instead.
+
+---
+
+LapScope is an unofficial, fan-made tool and is not affiliated with or endorsed
+by Playground Games, Turn 10, or Microsoft.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,15 +91,19 @@ lands on it except a green, reviewed PR.
 These are enforced in the GitHub repo settings; contributors just need to know
 what they imply:
 
-- **No direct pushes to `main`** — all changes go through a pull request.
-- **A pull request is required**, with at least **one approving review** and all
-  review conversations resolved before merge.
+- **No direct pushes to `main`** — all changes go through a pull request (rules
+  apply to admins too).
+- **A pull request is required**, with all review conversations resolved before
+  merge. Required approvals are currently **0** (LapScope is solo-maintained, and
+  GitHub won't let you approve your own PR); this will move to **≥1** once there
+  are other reviewers.
 - **Status checks must pass** before merging — the required check is **`test`**
   (the CI workflow: `ruff`, the `packet.py` self-test, and `pytest`).
 - **Branches must be up to date with `main`** before merging (so CI runs against
-  the final merged state).
+  the final merged state), and **linear history** is required.
 - **Squash and merge is the only allowed merge method** — merge commits and
-  rebase merges are disabled, so `main` stays one commit per PR.
+  rebase merges are disabled, so `main` stays one commit per PR. Head branches
+  are auto-deleted after merge.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ event-detection model, the hard-won FH6 quirks) is in the **[Wiki](../../wiki)**
 ## Contributing
 
 [Issues](../../issues) and PRs welcome — especially **captures of event types that
-aren't detected yet** and **car-ordinal additions**. See [ARCHITECTURE.md](ARCHITECTURE.md)
-for the code map and [AGENTS.md](AGENTS.md) for the dev workflow.
+aren't detected yet** and **car-ordinal additions**. Start with
+[CONTRIBUTING.md](CONTRIBUTING.md) (workflow, branch rules, how to file a capture);
+see [ARCHITECTURE.md](ARCHITECTURE.md) for the code map, [AGENTS.md](AGENTS.md) for
+the dev workflow, and our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -29,9 +29,10 @@ Ideas.**
   Analysis/session shots are from real recorded sessions; the hero was captured live.
 - **CI on pull requests** (see Testing & CI) — required before opening the repo
   to outside PRs.
-- **Repo hygiene files:** `CONTRIBUTING.md`, issue templates (bug / feature /
-  "unrecognized event type" capture report), a PR template, and a short
-  `CODE_OF_CONDUCT.md`. Document the branch-protection rules in CONTRIBUTING.
+- **Repo hygiene files:** ✅ Added `CONTRIBUTING.md` (workflow + branch-protection
+  rules + squash-merge), `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), a PR
+  template, and issue forms (bug / feature / "unrecognized event" capture) with
+  an `ISSUE_TEMPLATE/config.yml`. README's Contributing section links them.
 
 ## Distribution & packaging (make it plug & play)
 
@@ -101,9 +102,11 @@ the build. Playground Games ships new cars → new ordinals, so it goes stale.
   self-test + pytest on every push and pull request.
 - ✅ **Build the exe on version tags** — [.github/workflows/release.yml](.github/workflows/release.yml)
   builds and publishes the exe on `v*` tags only.
-- **Branch protection** on `main` (needs the GitHub remote): require a PR and the
-  passing CI check, no direct pushes. Enable in repo settings once pushed and
-  document the rule in CONTRIBUTING.
+- **Branch protection** on `main`: require a PR + review, the passing `test` CI
+  check, up-to-date branches, and no direct pushes; allow **squash-merge only**.
+  Rules documented in [CONTRIBUTING.md](CONTRIBUTING.md); apply them in the GitHub
+  repo settings (Settings → Branches / General — see the checklist handed over
+  when this landed).
 
 ## Docs
 


### PR DESCRIPTION
## Summary

Adds the repo-hygiene files for going public (TODO.md "Repo hygiene files" +
"Branch protection"):

- **CONTRIBUTING.md** — dev setup, the branch → PR → **squash-merge** workflow,
  commit/PR style, and the `main` branch-protection rules written out for
  contributors.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (enforcement contact:
  @darcane).
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist (ruff / packet self-test /
  pytest, docs, simulator+test for new detection scenarios).
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml`, `feature_request.yml`, the
  `unrecognized_event.yml` capture report (wired to the `LS_KEEP_DISCARDED` +
  `inspect_session.py` workflow), and `config.yml` (blank issues off; links to
  Discussions / Wiki / private security advisory).
- README Contributing section links the new docs; the two TODO.md items are
  pruned.

## Branch protection applied on `main`

Configured via the GitHub API alongside this branch:

- PR required, **no direct pushes** (enforced on admins too), conversation
  resolution + linear history required.
- Required status check: **`test`**, strict (branch must be up to date).
- Force pushes and branch deletion blocked.
- Required approvals: **0** — solo maintainer; GitHub disallows self-approval, so
  0 keeps the owner able to merge while a PR + green CI stay mandatory. Bump to
  ≥1 when a co-maintainer is added.
- Merge policy: **squash-merge only** (merge commits + rebase disabled), squash
  commit uses PR title + body, head branches auto-deleted.

## Test plan

- [ ] CI (`test`: ruff + packet self-test + pytest) is green on this PR.
- [ ] Docs-only change — no runtime code touched.
- [ ] Issue forms render on the "New issue" chooser after merge.
