### PR TITLE
fix(recorder): flag hygiene on re-anchor, pending WTA crossing, race_mode at LastLap finish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,10 @@ All the rules exist because some real behavior broke a naive version:
   to the anchor after being ≥120 m away, traveling within ~75° of the launch
   heading, having covered ≥500 dist-units. The run finish is `DistanceTraveled`
   hard-resetting (~18000 → 0) while the clock keeps counting; the post-finish
-  coast "lap" is deleted. A single-frame position jump >250 m (fast travel)
+  coast "lap" is deleted. A crossing normally finalizes when the car *exits*
+  the crossing circle; a stream that dies inside it instead has the pending
+  closest approach finalized at session end, flagged `cutoff` (simulate with
+  `--wta 3 --cut`). A single-frame position jump >250 m (fast travel)
   disarms the geometric detection — you never teleport mid-run, so it's a
   free-roam giveaway. Remaining caveat: a fresh-boot free-roam session starting
   at `DistanceTraveled` 0 that loops back over its start point *without*
@@ -173,7 +176,8 @@ All the rules exist because some real behavior broke a naive version:
 - `SessionTracker.race_mode` (in the per-frame extras merged into every
   WebSocket frame, alongside `session_id`/`delta`/`lap_elapsed`): True while a
   timed event is running — `RacePosition > 0`, live lap fields, or the geometric
-  launch anchor armed; False in free roam and once the event finishes. The
+  launch anchor armed; False in free roam and once the event finishes (every
+  finish signal drops it, including the LastLap-change finish). The
   dashboard gates the lap timer, the RACE MODE / FREE ROAM chip, and the live
   track map on it. Verified transitions on real captures: race = on from the
   first grid frame; WTA = off during event-load/grid-hold, on at launch, off at
@@ -192,7 +196,9 @@ All the rules exist because some real behavior broke a naive version:
   roughly half of that race's spikes were landings, not the AI bumps they looked
   like), and light Rivals wall-scrapes stay below the threshold (false negatives;
   there is no lap-invalidated packet field to cross-check against). Improving
-  both is tracked in TODO.md ("Contact & lap-invalidation detection").
+  both is tracked in TODO.md ("Contact & lap-invalidation detection"). Flags
+  reset when a lap re-anchors (the WTA launch, a mid-session lap-timer start):
+  pre-launch junk frames must not dirty lap 1.
 - Routes are fingerprinted (start pos within 80 m + length within 5%) and named
   once by the user; names apply to every session on the route.
 - Sessions with zero completed laps/runs are discarded at close and again at
@@ -259,5 +265,6 @@ a row here, a test, and usually a simulator flag.
 | Touge (cut at line) | `--dirt 40 --cut` | single run ≈40 s flagged `cutoff` (CurrentLap counts, stream cut dead at speed), route assigned |
 | Sprint, stream cut at line | `--sprint 60 --cut` | session kept, single run ≈60 s flagged `cutoff`, route assigned |
 | World Time Attack | `--wta 3` | launch + 3 geometric laps + distance-reset finish, no post-finish phantom lap |
+| WTA, stream cut at the line | `--wta 3 --cut` | 3 geometric laps, last flagged `cutoff` (pending crossing finalized at session end), no phantom lap |
 | Jumps in 3D | `--sprint 75 --jumps` (or any + `--jumps`) | 3D map scale sane, spikes capped |
 | Race-mode gating | `--freeroam 35 --race 3` | chip FREE ROAM then RACE MODE; timer dashed in free roam; live map draws the race only |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -99,7 +99,9 @@ listener: `session_id`, `delta` (vs session-best), `session_best`,
   sprints (a looping sprint would falsely trip geometric lap detection).
   `--dirt` models the verified real point-to-point race (CurrentLap counts,
   `DistanceTraveled`-reset finish after a results-cinematic stream gap);
-  `--dirt … --cut` models the touge variant (stream cut dead at the line).
+  `--dirt … --cut` models the touge variant (stream cut dead at the line);
+  `--wta … --cut` dies inside the crossing circle at the final line (the
+  pending geometric crossing is finalized at session end, flagged `cutoff`).
 - [tools/inspect_session.py](tools/inspect_session.py) — dumps every
   segmentation-relevant signal transition of a stored session straight from
   the DB (`--list` to enumerate). The capture-diagnosis workflow is in the
@@ -112,6 +114,7 @@ listener: `session_id`, `delta` (vs session-best), `session_best`,
 | [tests/harness.py](tests/harness.py) | `FakeSocket` parses each packet the simulator "sends" and feeds it straight into a real `SessionTracker` + temp-file `Store`; the simulator's clock is stubbed (`_FastClock`) so a 3-minute scenario runs in milliseconds. `run(scenario, tmp_path, …)` plays a scenario and returns the closed store; `sessions()` / `completed_laps()` / `flags_of()` are assertion helpers. |
 | [tests/test_packet.py](tests/test_packet.py) | Packet invariants: `_STRUCT.size == PACKET_SIZE`, `FIELDS`↔`_STRUCT` value-count lockstep, scalar + wheel-array round trip. |
 | [tests/test_scenarios.py](tests/test_scenarios.py) | The AGENTS.md event-detection matrix as headless assertions (free-roam discard, dirty flags, race finish, sprint/dirt/touge point-to-point, WTA geometric laps, jumps). |
+| [tests/test_tracker.py](tests/test_tracker.py) | Direct-drive tracker regressions the scenarios can't stage: flag hygiene across lap re-anchors, `race_mode` dropping at a LastLap-change finish, the listener's crash-fallback frame shape. |
 | [conftest.py](conftest.py), [pyproject.toml](pyproject.toml) | Put the repo root + `tests/` on `sys.path`; `pytest` testpaths and `ruff` lint config (defaults: pyflakes F + E4/E7/E9, line length 100). |
 
 Run `pytest -q` and `ruff check .` from the repo root (tooling in

--- a/app/recorder/laps.py
+++ b/app/recorder/laps.py
@@ -69,7 +69,9 @@ launch point (where DistanceTraveled starts growing) is the anchor, and a
 lap completes at the closest approach to the anchor after driving away,
 provided the car is traveling roughly the same direction it launched in
 and has covered enough distance. The DistanceTraveled collapse is the
-run-finished signal.
+run-finished signal. A crossing normally finalizes when the car exits the
+crossing circle; if the stream dies inside it instead, the pending closest
+approach is finalized at session end and the lap flagged "cutoff".
 
 Sessions that end without a single completed lap or run (free-roam
 cruising, menu blips, abandoned events) are discarded entirely. Every
@@ -194,7 +196,8 @@ class SessionTracker:
                 elif t - self._race_off_since >= RACE_OFF_GRACE:
                     self._end_session(self._race_off_since)
             return {"session_id": self.session_id, "delta": None,
-                    "session_best": self.best_lap_time, "race_mode": False}
+                    "session_best": self.best_lap_time, "lap_elapsed": None,
+                    "race_mode": False}
 
         self._race_off_since = None
 
@@ -320,6 +323,11 @@ class SessionTracker:
 
     def _end_session(self, end_t: float) -> None:
         self.flush()
+        if self._lap_id is not None:
+            # a geometric crossing normally finalizes when the car exits the
+            # crossing circle; if the stream died inside it, the recorded
+            # closest approach is still pending - complete that lap now
+            self._finalize_wta_crossing(None)
         if self._lap_id is not None:
             is_run = True  # a point-to-point run (fingerprint the whole course)
             lap_time = self._point_to_point_run_time()
@@ -634,6 +642,7 @@ class SessionTracker:
             log.info("Session %d: event finish detected (last lap %.3fs)",
                      self.session_id, last)
             self._complete_current_lap(t, last, self._lap_number)
+            self._event_finished = True  # race_mode drops right at the line
             self._lap_id = None  # nothing to reopen: the event is over
         elif (self._lap_id is not None
               and self._prev_cur_lap is not None and self._prev_cur_lap <= 0.0
@@ -648,6 +657,7 @@ class SessionTracker:
             self._lap_start_dist = dist
             self._lap_start_pos = (frame["pos_x"], frame["pos_z"])
             self._cur_d, self._cur_t = [], []
+            self._lap_flags = set()  # the lap starts here; earlier flags aren't its
             self._lap_max_elapsed = 0.0
             self._lap_open_rt = rt
             self.store.restart_lap(self._lap_id, t, dist)
@@ -695,6 +705,7 @@ class SessionTracker:
                 self._lap_start_dist = dist
                 self._lap_start_pos = self._wta_anchor
                 self._cur_d, self._cur_t = [], []
+                self._lap_flags = set()  # pre-launch junk frames must not dirty lap 1
                 self._lap_max_elapsed = 0.0
                 self._lap_open_rt = rt
                 self.store.restart_lap(self._lap_id, t, dist)
@@ -726,8 +737,14 @@ class SessionTracker:
             self._finalize_wta_crossing(frame)
             self._wta_inside = False
 
-    def _finalize_wta_crossing(self, frame: dict) -> None:
-        """Close the lap at the recorded closest approach to the anchor."""
+    def _finalize_wta_crossing(self, frame: dict | None) -> None:
+        """Close the lap at the recorded closest approach to the anchor.
+
+        frame None = the session is ending with the crossing still pending
+        (the stream died inside the crossing circle before exiting it, which
+        is what normally finalizes a crossing): the lap is completed without
+        reopening a new one, flagged cutoff - the car might have passed
+        closer to the anchor had the stream continued."""
         if self._wta_best is None:
             return
         d, bt, brt, bdist, bx, bz = self._wta_best
@@ -735,10 +752,16 @@ class SessionTracker:
         lap_time = brt - (self._lap_open_rt if self._lap_open_rt is not None else brt)
         if lap_time <= 1.0:
             return
+        if frame is None:
+            self._lap_flags.add("cutoff")
         log.info("Session %d: geometric lap %d done: %.3fs (crossed %.1f m"
-                 " from the launch point)", self.session_id,
-                 self._completed_laps + 1, lap_time, d)
+                 " from the launch point%s)", self.session_id,
+                 self._completed_laps + 1, lap_time, d,
+                 ", finalized at stream end" if frame is None else "")
         self._complete_current_lap(bt, lap_time, self._lap_number)
+        if frame is None:
+            self._lap_id = None  # session is ending: nothing to reopen
+            return
         self._open_lap(bt, self._lap_number, bdist, frame,
                        stored_ln=self._completed_laps)
         # the reopen used the current frame; rebase it to the crossing itself

--- a/app/telemetry/listener.py
+++ b/app/telemetry/listener.py
@@ -46,7 +46,9 @@ class TelemetryProtocol(asyncio.DatagramProtocol):
             extras = self.tracker.on_frame(now, data, frame)
         except Exception:
             log.exception("Recorder failed on frame; telemetry stream continues")
-            extras = {"session_id": None, "delta": None}
+            # keep the documented frame shape (ARCHITECTURE.md, WS contract)
+            extras = {"session_id": None, "delta": None, "session_best": None,
+                      "lap_elapsed": None, "race_mode": False}
         frame.update(extras)
         frame["_t"] = now
         hub.publish(frame)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -155,6 +155,25 @@ def test_world_time_attack_three_geometric_laps(tmp_path):
     assert len(all_laps) == 3  # no phantom post-finish lap
 
 
+def test_wta_cut_dead_at_line(tmp_path):
+    """--wta 3 --cut: the stream dies right at the final geometric crossing
+    (inside the crossing circle, never exited); the pending crossing is
+    finalized at session end and the last lap flagged cutoff."""
+    def scenario(sim):
+        sim.wta(3, cut=True)  # no race_off: the stream just stops
+
+    store = run(scenario, tmp_path)
+    ss = sessions(store)
+
+    assert len(ss) == 1
+    all_laps = store.session_laps(ss[0]["id"])
+    timed = [lap for lap in all_laps if lap["lap_time"] is not None]
+    assert len(timed) == 3
+    assert len(all_laps) == 3  # no phantom open lap left behind
+    assert "cutoff" in flags_of(timed[-1])  # time inferred at the cut
+    assert flags_of(timed[0]) == "" and flags_of(timed[1]) == ""
+
+
 def test_jumps_do_not_break_a_point_to_point_run(tmp_path):
     """--sprint 75 --jumps: cross-country-style elevation spikes still record
     a single clean run (3D-map scaling is a frontend concern)."""

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,142 @@
+"""Targeted SessionTracker regressions the simulator scenarios can't stage.
+
+These drive hand-built packets straight into the tracker (no simulator
+course geometry) to pin down frame-exact behaviors: flag hygiene across lap
+re-anchors, race_mode dropping at a LastLap-change finish, and the
+listener's recorder-crash fallback keeping the WebSocket frame contract.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from app.recorder.laps import SessionTracker
+from app.recorder.store import Store
+from app.telemetry.packet import empty_fields, pack, parse
+
+
+class Driver:
+    """Feeds hand-built packets to a real tracker at a synthetic 60 Hz."""
+
+    def __init__(self, tmp_path) -> None:
+        self.store = Store(str(Path(tmp_path) / "telemetry.db"))
+        self.tracker = SessionTracker(self.store)
+        self.f = empty_fields()
+        self.f.update(is_race_on=1, car_ordinal=1, car_class=6, car_pi=900,
+                      drivetrain_type=2)
+        self.t = 0.0
+
+    def send(self, **kw) -> dict:
+        """Advance one frame (race clock included unless overridden) and
+        return the tracker extras for it."""
+        self.t += 1 / 60
+        self.f["current_race_time"] += 1 / 60
+        self.f.update(**kw)
+        raw = pack(self.f)
+        return self.tracker.on_frame(self.t, raw, parse(raw))
+
+    def finish(self) -> list[dict]:
+        """Close the session (stream went silent) and return its laps."""
+        self.tracker.shutdown(self.t + 20.0)
+        laps = self.store.session_laps(1)
+        self.store.close()
+        return laps
+
+
+def drive_circle(d: Driver, radius: float = 120.0, v: float = 40.0,
+                 laps: float = 1.3) -> None:
+    """Drive a circle through the launch point: one geometric (WTA) lap,
+    then far enough past it that the crossing finalizes on circle exit."""
+    dist, total = 0.0, 2 * math.pi * radius * laps
+    while dist < total:
+        dist += v / 60
+        ang = dist / radius
+        # circle centered at (0, radius), launched at the origin heading +x;
+        # the car moves along (sin yaw, cos yaw), so yaw = pi/2 - angle
+        d.send(pos_x=radius * math.sin(ang), pos_z=radius * (1 - math.cos(ang)),
+               distance_traveled=dist, speed=v, yaw=math.pi / 2 - ang,
+               accel_x=0.0)
+
+
+def test_pre_launch_contact_not_flagged_on_geometric_lap(tmp_path):
+    """A contact spike while parked at the WTA grid (event load / grid hold,
+    before launch) must not dirty lap 1: the launch re-anchor starts the lap
+    fresh, flags included."""
+    d = Driver(tmp_path)
+    for i in range(120):  # 2 s grid hold, DistanceTraveled pinned at 0
+        d.send(pos_x=0.0, pos_z=0.0, distance_traveled=0.0, speed=0.0,
+               accel_x=60.0 if i == 60 else 0.0)
+    drive_circle(d)
+    timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
+    assert len(timed) == 1
+    assert "contact" not in (timed[0]["flags"] or "")
+
+
+def test_mid_session_reanchor_clears_flags(tmp_path):
+    """A contact picked up while cruising before a free-roam time-attack's
+    lap timer starts must not stick to the re-anchored lap."""
+    d = Driver(tmp_path)
+    d.f["current_race_time"] = 50.0  # mid-session clock, no reset-split
+    x = 0.0
+
+    def cruise(**kw):
+        nonlocal x
+        x += 0.5
+        # odometer already ran (free roam), so the geometric path stays inert
+        d.send(pos_x=x, distance_traveled=5000.0 + x, speed=30.0, **kw)
+
+    for i in range(6 * 60):  # 6 s of cruising, lap fields dead
+        cruise(accel_x=60.0 if i == 120 else 0.0, current_lap=0.0)
+    for i in range(10 * 60):  # the lap timer starts: re-anchor fires here
+        cruise(current_lap=(i + 1) / 60, accel_x=0.0)
+    cruise(lap_number=1, current_lap=0.0, last_lap=10.0)  # line crossed
+
+    timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
+    assert len(timed) == 1
+    assert timed[0]["lap_time"] == 10.0
+    assert "contact" not in (timed[0]["flags"] or "")
+
+
+def test_race_mode_drops_at_lastlap_finish(tmp_path):
+    """The LastLap-change finish ends the event: race_mode must go False on
+    that frame, not seconds later when the clock freeze is noticed."""
+    d = Driver(tmp_path)
+    d.f["race_position"] = 3  # gridded
+    for i in range(6 * 60):  # lap 1
+        d.send(current_lap=(i + 1) / 60, distance_traveled=(i + 1) * 1.0,
+               speed=60.0)
+    d.send(lap_number=1, current_lap=0.0, last_lap=62.0,
+           distance_traveled=361.0, speed=60.0)
+    for i in range(6 * 60):  # lap 2 (the final lap)
+        extras = d.send(current_lap=(i + 1) / 60,
+                        distance_traveled=362.0 + i, speed=60.0)
+        assert extras["race_mode"] is True
+    # finish: LastLap changes while LapNumber stays put
+    extras = d.send(last_lap=61.5, current_lap=0.0, speed=60.0)
+    assert extras["race_mode"] is False
+    extras = d.send(speed=40.0)  # post-finish coast stays out of race mode
+    assert extras["race_mode"] is False
+
+    timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
+    assert [lap["lap_time"] for lap in timed] == [62.0, 61.5]
+
+
+def test_listener_fallback_keeps_frame_contract(tmp_path):
+    """A recorder crash must not shrink the published frame: the extras keep
+    the documented shape (session_id/delta/session_best/lap_elapsed/race_mode)."""
+    from app.telemetry.hub import Hub
+    from app.telemetry.listener import TelemetryProtocol
+
+    class Boom:
+        def on_frame(self, t, raw, frame):
+            raise RuntimeError("boom")
+
+    hub = Hub()
+    q = hub.subscribe()
+    proto = TelemetryProtocol(hub, Boom())
+    proto.datagram_received(pack(empty_fields()), ("127.0.0.1", 50000))
+    frame = q.get_nowait()
+    for key in ("session_id", "delta", "session_best", "lap_elapsed", "race_mode"):
+        assert key in frame
+    assert frame["race_mode"] is False

--- a/tools/simulator.py
+++ b/tools/simulator.py
@@ -306,13 +306,16 @@ class Sim:
             return
         self._finish_freeze(t, 0, 0.0, 0.0)
 
-    def wta(self, laps: int) -> None:
+    def wta(self, laps: int, cut: bool = False) -> None:
         """World Time Attack (mirrors a real capture): every lap field stays
         0 for the whole event; the race clock counts from event load through
         a teleport to the track and a grid hold with DistanceTraveled pinned
         at 0; at the finish the game auto-stops the car and hard-resets
-        DistanceTraveled while the clock keeps counting."""
-        print(f"wta ({laps} laps): no lap fields at all - geometric detection")
+        DistanceTraveled while the clock keeps counting. cut=True models the
+        stream dying right at the final crossing instead: a few frames inside
+        the crossing circle, then silence - no auto-stop, no reset."""
+        print(f"wta ({laps} laps): no lap fields at all - geometric detection"
+              f"{' [stream cuts at the line]' if cut else ''}")
         dead = dict(lap_no=0, cur_lap=0.0, last=0.0, best=0.0)
         self.f["race_position"] = 0  # verified on the real capture
         t = 0.0
@@ -340,6 +343,16 @@ class Sim:
                 lap_start = t
                 self.pace = random.uniform(0.955, 1.0)
             self._send(race_time=t, **dead)
+        if cut:
+            # stream dies right at the line: a few more frames inside the
+            # crossing circle (the closest approach is recorded but the circle
+            # is never exited), then silence - no auto-stop, no distance reset
+            print(f"  crossed the final line at rt={t:.1f}s - stream cuts dead")
+            for _ in range(int(0.25 / self.dt)):
+                self._pace_tick()
+                t += self.dt
+                self._send(race_time=t, **dead)
+            return
         while self.v > 0.5:  # auto-stop after the line
             t += self.dt
             self.v = max(0.0, self.v - 6.0 * self.dt)
@@ -463,9 +476,9 @@ def main() -> None:
                          " counts, LapNumber stays 0, DistanceTraveled-reset finish"
                          " - matches the verified capture)")
     ap.add_argument("--cut", action="store_true",
-                    help="with --sprint or --dirt: cut the stream dead at the"
-                         " finish line (touge/circuit-style) instead of the"
-                         " frozen clock / odometer-reset handback")
+                    help="with --sprint, --dirt or --wta: cut the stream dead"
+                         " at the finish line (touge/circuit-style) instead of"
+                         " the frozen clock / odometer-reset handback")
     ap.add_argument("--wta", type=int, default=0, metavar="LAPS",
                     help="run a World Time Attack: all lap fields dead, laps"
                          " only detectable geometrically")
@@ -482,7 +495,7 @@ def main() -> None:
     if args.freeroam > 0:
         sim.freeroam(args.freeroam)
     if args.wta > 0:
-        sim.wta(args.wta)
+        sim.wta(args.wta, cut=args.cut)
     elif args.dirt > 0:
         sim.dirt_sprint(args.dirt, cut=args.cut)
     elif args.sprint > 0:
@@ -494,7 +507,7 @@ def main() -> None:
         for i in range(args.events):
             sim.event(args.duration / args.events, f"event {i + 1}/{args.events}",
                       dirty=args.dirty)
-    if not ((args.sprint > 0 or args.dirt > 0) and args.cut):
+    if not ((args.sprint > 0 or args.dirt > 0 or args.wta > 0) and args.cut):
         sim.race_off()  # a cut stream ends in silence, not race-off frames
     print(f"Done: {sim.sent} packets.")
 


### PR DESCRIPTION
Closes #9

Four recorder-correctness fixes from the 2026-07-08 audit.

## What

- **Flag hygiene across lap re-anchors** — `_lap_flags` is now cleared when a lap re-anchors (the WTA launch, a mid-session lap-timer start). A contact spike during event load / teleport / grid hold no longer dirties lap 1 (confirmed by repro before the fix).
- **Pending geometric crossing finalized at session end** — a crossing normally finalizes when the car *exits* the 60 m crossing circle; if the stream died inside it, the recorded closest approach was silently discarded (a single-lap WTA session was dropped entirely). `_end_session` now completes that lap at the recorded pass and flags it `cutoff` (the car might have passed closer had the stream continued). The simulator grows `--wta N --cut` to model it.
- **`race_mode` drops at the LastLap-change finish** — the finish branch now sets `_event_finished`, so the RACE MODE chip / lap timer gate turn off at the line instead of ~1.5 s later via the clock-freeze fallback, matching the documented contract in AGENTS.md.
- **WS frame contract kept on recorder crash** — the listener's fallback extras (and the race-off return) now carry the full documented shape (`session_best` / `lap_elapsed` / `race_mode` were missing).

## Tests

- New `tests/test_tracker.py`: direct-drive regressions for all four (pre-launch contact not flagged, re-anchor clears flags, race_mode at the LastLap finish, listener fallback shape).
- New scenario row: `--wta 3 --cut` → 3 geometric laps, last flagged `cutoff`, no phantom lap.
- All 5 new tests verified to **fail on the pre-fix code** and pass with the fixes. Full suite: 20/20, ruff clean, packet self-test OK.

## Docs

AGENTS.md (WTA bullet, dirty-lap bullet, race_mode bullet, test-matrix row) and ARCHITECTURE.md (simulator `--cut` scope, tests table) updated per the repo's detection-change checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
