### PR TITLE
fix(api): lap_time channel falls back to elapsed time when the lap clock never ran

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,7 +68,7 @@ each runs on every startup inside try/except (existing-column errors swallowed).
 | `POST /sessions/{id}/reprocess` | Rebuild laps from stored frames (async def — event-loop writes). 409 while recording. |
 | `DELETE /sessions/{id}` | Cascades frames+laps. 409 while recording. |
 | `GET /sessions/{id}/laps` | Session + laps with `is_best` / `gap_to_best`. |
-| `GET /laps/{id}/data?channels=&max_points=` | Distance-indexed channel arrays; drops rewound-over samples; decimates to `max_points`. Channel names = `CHANNELS` keys in routes.py. |
+| `GET /laps/{id}/data?channels=&max_points=` | Distance-indexed channel arrays; drops rewound-over samples; decimates to `max_points`. Channel names = `CHANNELS` keys in routes.py. `lap_time` falls back to time-since-lap-start when the packet lap clock never ran (WTA / bare sprints keep `CurrentLap` at 0), so the A/B Δ-time chart works for those events. |
 | `PATCH /routes/{id}`, `GET/PATCH /cars/{ordinal}` | Rename route / car override. |
 
 ## WebSocket `/ws/live` frame
@@ -115,6 +115,7 @@ listener: `session_id`, `delta` (vs session-best), `session_best`,
 | [tests/test_packet.py](tests/test_packet.py) | Packet invariants: `_STRUCT.size == PACKET_SIZE`, `FIELDS`↔`_STRUCT` value-count lockstep, scalar + wheel-array round trip. |
 | [tests/test_scenarios.py](tests/test_scenarios.py) | The AGENTS.md event-detection matrix as headless assertions (free-roam discard, dirty flags, race finish, sprint/dirt/touge point-to-point, WTA geometric laps, jumps). |
 | [tests/test_tracker.py](tests/test_tracker.py) | Direct-drive tracker regressions the scenarios can't stage: flag hygiene across lap re-anchors, `race_mode` dropping at a LastLap-change finish, the listener's crash-fallback frame shape. |
+| [tests/test_api.py](tests/test_api.py) | Endpoint functions run directly against a harness-produced store (stub request, no HTTP server): the `lap_time` channel fallback for dead lap clocks. |
 | [conftest.py](conftest.py), [pyproject.toml](pyproject.toml) | Put the repo root + `tests/` on `sys.path`; `pytest` testpaths and `ruff` lint config (defaults: pyflakes F + E4/E7/E9, line length 100). |
 
 Run `pytest -q` and `ruff check .` from the repo root (tooling in

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -50,6 +50,8 @@ CHANNELS = {
     "slip_rear": lambda p: (p["tire_combined_slip"][2] + p["tire_combined_slip"][3]) / 2,
     "slip_max": lambda p: max(p["tire_combined_slip"]),
     "boost": lambda p: p["boost"],
+    # falls back to time-since-lap-start when the lap clock never ran (WTA /
+    # bare sprints keep CurrentLap at 0) - see the post-pass in lap_data()
     "lap_time": lambda p: p["current_lap"],
     "pos_x": lambda p: p["pos_x"],
     "pos_y": lambda p: p["pos_y"],   # elevation (world up-axis, meters)
@@ -268,6 +270,14 @@ def lap_data(
         t_rel.append(round(t - t0, 3))
         for n in names:
             out[n].append(round(CHANNELS[n](p), 4))
+
+    # World Time Attack and bare sprints broadcast no lap clock at all
+    # (CurrentLap stays 0 for the whole event), which made the A/B delta-time
+    # chart a flat zero line for exactly those events. Fall back to time since
+    # the lap's first frame - restart_lap re-anchors geometric laps at launch,
+    # so it counts from the line like a live lap clock would.
+    if "lap_time" in out and not any(v > 0.5 for v in out["lap_time"]):
+        out["lap_time"] = list(t_rel)
 
     return {"lap": lap, "n_frames": len(rows), "dist": dist, "t": t_rel,
             "channels": out, "collisions": collisions}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,50 @@
+"""API-level checks: the real endpoint functions run against a store the
+harness produced. The handlers are plain functions reading
+``request.app.state``, so a stub request object is enough - no HTTP server,
+no httpx, same zero-dependency footprint as the rest of the tests.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from harness import completed_laps, run, sessions
+
+
+def _request_for(store):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(store=store)))
+
+
+def test_lap_time_channel_falls_back_when_lap_clock_dead(tmp_path):
+    """World Time Attack broadcasts CurrentLap 0 for the whole event; the
+    lap_time channel must fall back to time-since-lap-start so the A/B
+    delta-time chart isn't a flat zero line."""
+    from app.api.routes import lap_data
+
+    def scenario(sim):
+        sim.wta(2)
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    lap = completed_laps(store, sessions(store)[0]["id"])[0]
+    data = lap_data(lap["id"], _request_for(store), "lap_time,speed_kmh", 500)
+
+    lt = data["channels"]["lap_time"]
+    assert lt == data["t"]  # substituted with time since the lap's first frame
+    assert lt[-1] > 10.0    # and it actually counts across the lap
+    assert any(v > 1.0 for v in data["channels"]["speed_kmh"])  # others untouched
+
+
+def test_lap_time_channel_kept_when_lap_clock_alive(tmp_path):
+    """A circuit lap's CurrentLap is real telemetry and must pass through
+    (alive channel, no zeroing, no substitution surprises)."""
+    from app.api.routes import lap_data
+
+    def scenario(sim):
+        sim.event(120, "event")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    lap = completed_laps(store, sessions(store)[0]["id"])[0]
+    data = lap_data(lap["id"], _request_for(store), "lap_time", 500)
+    assert any(v > 0.5 for v in data["channels"]["lap_time"])


### PR DESCRIPTION
Closes #10

## What

The A/B **Δ-time comparison chart** on the analysis page is built from the `lap_time` channel, which maps to the packet's `CurrentLap`. World Time Attack and bare sprints keep `CurrentLap` at 0 for the whole event (verified on real captures, per AGENTS.md) — so comparing two such laps rendered a meaningless flat Δt = 0 line for exactly the event types the recorder works hardest to support.

`lap_data()` now falls back to **time since the lap's first frame** when the requested `lap_time` channel is dead across the whole lap. `restart_lap` re-anchors geometric (WTA) laps at launch, so the fallback counts from the line like a live lap clock would. Laps with a real `CurrentLap` pass through unchanged, and the frontend needs no changes.

## Tests

New `tests/test_api.py` — the endpoint functions are plain functions reading `request.app.state`, so they run directly against a harness-produced store with a stub request (no HTTP server, no new dependencies):

- WTA lap → `lap_time` equals the `t` array (fallback engaged) and actually counts.
- Circuit lap → real `CurrentLap` passes through.

Full suite 22/22, ruff clean.

## Docs

ARCHITECTURE.md: `/laps/{id}/data` row documents the fallback; tests table gains `test_api.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
