### PR TITLE
fix(api): block reprocess during any recording; empty name clears session/car names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,9 @@ All the rules exist because some real behavior broke a naive version:
 - `POST /api/sessions/{id}/reprocess` (UI: Reprocess button) replays stored
   frames through a fresh `SessionTracker` via `_ReplayStore` (laps/routes real,
   session row untouched, discard suppressed) — recovers laps recorded before a
-  detection fix. Must stay `async def` (writes on the event-loop connection).
+  detection fix. Must stay `async def` (writes on the event-loop connection),
+  which also means the replay blocks the loop — it 409s while **any** session
+  is recording, or a long replay would freeze live telemetry mid-race.
 - `sessions.kept = 1` exempts a session from the startup no-laps cleanup
   (LS_KEEP_DISCARDED captures and reprocessed sessions set it).
 - Dirty-lap inference: rewind = lap clock below its high-water mark while

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,12 +64,12 @@ each runs on every startup inside try/except (existing-column errors swallowed).
 | `GET /status` | Packet counters, last-packet age/size, active session, session best, `version` (`app.__version__`), and `udp_error` (non-null when the UDP port could not be bound). First stop when "nothing works". |
 | `GET /version` | `{"version": app.__version__}` — the running build. The frontend compares it (client-side) against the latest GitHub Release for the update notice; `"0.0.0"` (dev/source run) suppresses the check. |
 | `GET /sessions` | List with route/car-name joins, lap counts, best lap. |
-| `PATCH /sessions/{id}` | `name`, `conditions` (`dry/wet/snow`, `""` clears), `track_type` (`road/street/touge/dirt/cross/drag/wtc`, `""` clears). |
-| `POST /sessions/{id}/reprocess` | Rebuild laps from stored frames (async def — event-loop writes). 409 while recording. |
+| `PATCH /sessions/{id}` | `name` (`""` clears → display falls back to route/date), `conditions` (`dry/wet/snow`, `""` clears), `track_type` (`road/street/touge/dirt/cross/drag/wtc`, `""` clears). |
+| `POST /sessions/{id}/reprocess` | Rebuild laps from stored frames (async def — event-loop writes). 409 while **any** session records: the synchronous replay would stall the event loop and freeze live telemetry. |
 | `DELETE /sessions/{id}` | Cascades frames+laps. 409 while recording. |
 | `GET /sessions/{id}/laps` | Session + laps with `is_best` / `gap_to_best`. |
 | `GET /laps/{id}/data?channels=&max_points=` | Distance-indexed channel arrays; drops rewound-over samples; decimates to `max_points`. Channel names = `CHANNELS` keys in routes.py. `lap_time` falls back to time-since-lap-start when the packet lap clock never ran (WTA / bare sprints keep `CurrentLap` at 0), so the A/B Δ-time chart works for those events. |
-| `PATCH /routes/{id}`, `GET/PATCH /cars/{ordinal}` | Rename route / car override. |
+| `PATCH /routes/{id}`, `GET/PATCH /cars/{ordinal}` | Rename route / car override (car `name: ""` reverts the override to the bundled name). |
 
 ## WebSocket `/ws/live` frame
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -122,8 +122,8 @@ def patch_session(session_id: int, body: SessionPatch, request: Request):
     store = request.app.state.store
     if store.get_session(session_id) is None:
         raise HTTPException(404, "session not found")
-    if body.name is not None and body.name.strip():
-        store.rename_session(session_id, body.name.strip()[:80])
+    if body.name is not None:  # "" clears back to the route/date fallback
+        store.rename_session(session_id, body.name.strip()[:80] or None)
     if body.conditions is not None:  # "" clears the tag back to not-set
         if body.conditions and body.conditions not in CONDITIONS:
             raise HTTPException(400, f"conditions must be one of {sorted(CONDITIONS)}")
@@ -139,12 +139,14 @@ def patch_session(session_id: int, body: SessionPatch, request: Request):
 async def reprocess(session_id: int, request: Request):
     """Rebuild the session's laps from its stored frames with the current
     detection logic. async on purpose: the replay writes laps through the
-    Store's event-loop connection."""
+    Store's event-loop connection — which also means it blocks the loop for
+    the whole replay, so it must not run while ANY session is recording
+    (a long replay would freeze live telemetry and the dashboard mid-race)."""
     store = request.app.state.store
     if store.get_session(session_id) is None:
         raise HTTPException(404, "session not found")
-    if request.app.state.tracker.session_id == session_id:
-        raise HTTPException(409, "session is currently recording")
+    if request.app.state.tracker.session_id is not None:
+        raise HTTPException(409, "a session is recording; retry after it ends")
     return {"ok": True, "laps": reprocess_session(store, session_id)}
 
 
@@ -181,9 +183,11 @@ def car_name(ordinal: int, request: Request):
 
 @router.patch("/cars/{ordinal}")
 def set_car_name(ordinal: int, body: NameBody, request: Request):
-    if not body.name.strip():
-        raise HTTPException(400, "name must not be empty")
-    request.app.state.store.set_car_name(ordinal, body.name.strip()[:80])
+    name = body.name.strip()
+    if name:
+        request.app.state.store.set_car_name(ordinal, name[:80])
+    else:  # "" reverts to the bundled name (or "Car #<ordinal>")
+        request.app.state.store.clear_car_name(ordinal)
     return {"ok": True}
 
 

--- a/app/recorder/store.py
+++ b/app/recorder/store.py
@@ -243,7 +243,7 @@ class Store:
                                (session_id,)).fetchone()
         return dict(row) if row else None
 
-    def rename_session(self, session_id: int, name: str) -> None:
+    def rename_session(self, session_id: int, name: str | None) -> None:
         with self.reader() as conn:
             conn.execute("UPDATE sessions SET name = ? WHERE id = ?", (name, session_id))
             conn.commit()
@@ -273,6 +273,11 @@ class Store:
                 " ON CONFLICT(ordinal) DO UPDATE SET name = excluded.name",
                 (ordinal, name),
             )
+            conn.commit()
+
+    def clear_car_name(self, ordinal: int) -> None:
+        with self.reader() as conn:
+            conn.execute("DELETE FROM car_names WHERE ordinal = ?", (ordinal,))
             conn.commit()
 
     def get_car_override(self, ordinal: int) -> str | None:

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -166,9 +166,9 @@ async function renameSession(session) {
   const name = await uiPrompt("Rename session", {
     value: session.name || "",
     placeholder: displayName(session),
-    message: "Shown in the session list on the left.",
+    message: "Shown in the session list on the left. Leave empty to reset.",
   });
-  if (name === null || !name.trim()) return;
+  if (name === null) return;  // cancelled; "" clears back to the fallback name
   await fetch(`/api/sessions/${session.id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
@@ -199,9 +199,9 @@ async function renameRoute(session) {
 async function renameCar(session) {
   const name = await uiPrompt("Name car", {
     value: session.car_name || "",
-    message: "Applies everywhere this car appears.",
+    message: "Applies everywhere this car appears. Leave empty to reset to the built-in name.",
   });
-  if (name === null || !name.trim()) return;
+  if (name === null) return;  // cancelled; "" reverts to the bundled name
   await fetch(`/api/cars/${session.car_ordinal}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,13 +6,19 @@ no httpx, same zero-dependency footprint as the rest of the tests.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
+import pytest
+from fastapi import HTTPException
+
 from harness import completed_laps, run, sessions
+from app.recorder.store import Store
 
 
-def _request_for(store):
-    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(store=store)))
+def _request_for(store, tracker=None):
+    return SimpleNamespace(app=SimpleNamespace(
+        state=SimpleNamespace(store=store, tracker=tracker)))
 
 
 def test_lap_time_channel_falls_back_when_lap_clock_dead(tmp_path):
@@ -48,3 +54,74 @@ def test_lap_time_channel_kept_when_lap_clock_alive(tmp_path):
     lap = completed_laps(store, sessions(store)[0]["id"])[0]
     data = lap_data(lap["id"], _request_for(store), "lap_time", 500)
     assert any(v > 0.5 for v in data["channels"]["lap_time"])
+
+
+def test_session_name_patch_sets_and_clears(tmp_path):
+    """``name: ""`` must clear the custom name back to NULL so display_name
+    falls back to route/date, and a PATCH without name must leave it alone.
+    Regression: "" used to be silently ignored, so a name could never be
+    cleared (issue #11)."""
+    from app.api.routes import SessionPatch, patch_session
+
+    def scenario(sim):
+        sim.event(120, "event")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    sid = sessions(store)[0]["id"]
+    req = _request_for(store)
+
+    patch_session(sid, SessionPatch(name="  Sunset Sprint PB  "), req)
+    assert store.get_session(sid)["name"] == "Sunset Sprint PB"
+
+    patch_session(sid, SessionPatch(conditions="wet"), req)  # name omitted
+    assert store.get_session(sid)["name"] == "Sunset Sprint PB"
+
+    patch_session(sid, SessionPatch(name=""), req)
+    assert store.get_session(sid)["name"] is None
+
+
+def test_reprocess_blocked_while_any_session_records(tmp_path):
+    """The replay runs synchronously on the event loop, so reprocess must 409
+    while ANY session is recording - not only when the target session is the
+    live one (a long replay would freeze live telemetry mid-race, issue #11).
+    With the tracker idle it must still run and rebuild the same laps."""
+    from app.api.routes import reprocess
+
+    def scenario(sim):
+        sim.event(120, "event")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    session = sessions(store)[0]
+    sid = session["id"]
+
+    recording_other = _request_for(store, SimpleNamespace(session_id=sid + 1))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(reprocess(sid, recording_other))
+    assert exc.value.status_code == 409
+
+    # run() closed the event-loop connection the replay writes through
+    store2 = Store(store.db_path)
+    idle = _request_for(store2, SimpleNamespace(session_id=None))
+    out = asyncio.run(reprocess(sid, idle))
+    store2.close()
+    assert out["ok"] and out["laps"] == session["lap_count"]
+
+
+def test_car_override_set_and_clear(tmp_path):
+    """``name: ""`` on PATCH /cars deletes the override so the bundled name
+    (or "Car #<ordinal>") shows again (issue #11, optional revert path)."""
+    from app.api.routes import NameBody, car_name, set_car_name
+
+    store = Store(str(tmp_path / "cars.db"))
+    req = _request_for(store)
+
+    set_car_name(999999, NameBody(name="  Kebab GT  "), req)
+    assert car_name(999999, req) == {"ordinal": 999999, "name": "Kebab GT",
+                                     "known": True}
+
+    set_car_name(999999, NameBody(name="   "), req)
+    out = car_name(999999, req)
+    store.close()
+    assert out["known"] is False and out["name"] == "Car #999999"


### PR DESCRIPTION
Closes #11 (from the 2026-07-08 full-code audit).

## Changes

- **`POST /sessions/{id}/reprocess` now 409s while _any_ session is recording**, not just the target one. The replay runs synchronously on the event loop (Store's event-loop connection, by design), so a long session would freeze live telemetry and the dashboard mid-race.
- **`PATCH /sessions/{id}` with `name: ""` clears the custom name** back to NULL so `display_name` falls back to route/date. The rename dialog sends the cleared value instead of treating empty as cancel (only Cancel/Escape bails now).
- **`PATCH /cars/{ordinal}` with `name: ""` reverts the override** (new `Store.clear_car_name`) so the bundled name / `Car #N` shows again — the optional revert path from the issue. The "Name car" dialog gained the same empty-to-reset flow.
- ARCHITECTURE.md API table and the AGENTS.md reprocess bullet updated to document the new semantics.

## Testing

- 3 new regression tests in `tests/test_api.py`: name set/clear via the real handler, reprocess 409 while another session records + idle replay rebuilding the same lap count, car override set/clear. `pytest -q`: 25 passed; `ruff check .` clean.
- Verified end-to-end from a source run on a scratch DB: rename set/clear and car override set/clear through the real dialogs, idle reprocess returning the same laps, and a 409 on reprocessing an old session while the simulator recorded a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)