### PR TITLE
fix: HTTP port-conflict message, live DPR, pickLap races, dead map code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,7 +144,10 @@ assert them here.
 - Entry point [run_desktop.py](run_desktop.py): defaults `DATA_DIR` to
   `%LOCALAPPDATA%\LapScope`, runs uvicorn on `127.0.0.1:8000`, and opens the
   browser. It imports the `app.main:app` object by reference (not the string
-  form) so PyInstaller statically follows the whole `app` package.
+  form) so PyInstaller statically follows the whole `app` package. A busy
+  HTTP port is pre-checked with an actionable message + pause-before-exit
+  (a second double-clicked exe must not crash-exit with an unreadable
+  console flash — mirrors the UDP-port handling in `app/main.py`).
 - [LapScope.spec](LapScope.spec): PyInstaller **onedir** build. Bundles the full
   `app/static/` tree via `Tree(...)` (HTML/CSS/JS **plus** the binary
   `fonts/*.woff2`, `css/uplot.min.css`, `js/vendor/uplot.iife.min.js`) to

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -153,9 +153,22 @@ async function pickLap(lapId, slot) {
     state[dataKey] = null;
   } else {
     state[key] = lapId;
+    state[dataKey] = null;
     renderLapRows();
-    state[dataKey] = await (await fetch(
-      `/api/laps/${lapId}/data?channels=${LAP_CHANNELS}&max_points=1500`)).json();
+    try {
+      const res = await fetch(
+        `/api/laps/${lapId}/data?channels=${LAP_CHANNELS}&max_points=1500`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      // rapid clicks race their fetches: only the pick that still owns the
+      // slot may write it - a stale response must not overwrite a newer one
+      if (state[key] !== lapId) return;
+      state[dataKey] = data;
+    } catch (err) {
+      if (state[key] !== lapId) return; // stale failure; the newer pick renders
+      state[key] = null;                // untag so the row doesn't lie
+      uiAlert("Couldn't load lap data", String(err.message || err));
+    }
   }
   renderLapRows();
   drawMap();
@@ -329,6 +342,10 @@ function drawMap() {
   const A = state.dataA, B = state.dataB;
   const three = state.mapMode === "3d";
   canvas.style.cursor = three ? "grab" : "default";
+  if (!A) { // the side stats and color legend describe lap A - don't let
+    $("#map-side").innerHTML = "";      // them show a lap that was untagged
+    $("#legend-scale").innerHTML = "";
+  }
   if (!A && !B) return;
 
   // world extent (elevation exaggeration is derived from it)

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,14 +1,18 @@
 /* Live dashboard: WebSocket feed -> canvas gauges at display refresh rate. */
 
-const rpmG = initCanvas("rpm", 290, 250);
-const fricG = initCanvas("friction", 250, 240);
-const gripG = initCanvas("grip", 230, 240);
-let stripG = initCanvas("strip", document.getElementById("strip").parentElement.clientWidth - 34, 280);
-let liveMapG = initCanvas("livemap", document.getElementById("livemap").parentElement.clientWidth - 34, 280);
-window.addEventListener("resize", () => {
+let rpmG, fricG, gripG, stripG, liveMapG;
+function initCanvases() {
+  // re-run in full on resize: browser zoom / a different-DPI monitor changes
+  // devicePixelRatio, and every canvas needs the new backing scale, not just
+  // the two whose CSS width follows the layout
+  rpmG = initCanvas("rpm", 290, 250);
+  fricG = initCanvas("friction", 250, 240);
+  gripG = initCanvas("grip", 230, 240);
   stripG = initCanvas("strip", document.getElementById("strip").parentElement.clientWidth - 34, 280);
   liveMapG = initCanvas("livemap", document.getElementById("livemap").parentElement.clientWidth - 34, 280);
-});
+}
+initCanvases();
+window.addEventListener("resize", initCanvases);
 
 const STRIP_CAP = 12 * 60; // ~12 s at 60 Hz
 const state = {
@@ -28,8 +32,8 @@ const LIVEMAP_CAP = 4000;
 // mirrors IMPACT_ACCEL in app/recorder/laps.py (keep the two in lockstep).
 const IMPACT_ACCEL = 45;
 const liveMap = {
-  pts: [],         // [x, z] world points; null = teleport break
-  last: null,      // last stored point (skips the nulls)
+  pts: [],         // [x, z] world points
+  last: null,      // last stored point
   minDist: 3,      // m between stored points; doubles when thinned
   session: null,
   minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity,
@@ -92,7 +96,7 @@ function feedLiveMap(f) {
   liveMap.minX = Math.min(liveMap.minX, x); liveMap.maxX = Math.max(liveMap.maxX, x);
   liveMap.minZ = Math.min(liveMap.minZ, z); liveMap.maxZ = Math.max(liveMap.maxZ, z);
   if (liveMap.pts.length > LIVEMAP_CAP) { // free roam can sprawl: thin + relax
-    liveMap.pts = liveMap.pts.filter((p, i) => p === null || i % 2 === 0);
+    liveMap.pts = liveMap.pts.filter((_, i) => i % 2 === 0);
     liveMap.minDist *= 2;
   }
 }

--- a/app/static/js/gauges.js
+++ b/app/static/js/gauges.js
@@ -2,16 +2,18 @@
    tire grip diagram, input strip chart. All draw* functions are pure
    renders of the state passed in. */
 
-const DPR = window.devicePixelRatio || 1;
-
 function initCanvas(id, cssW, cssH) {
   const c = document.getElementById(id);
-  c.width = cssW * DPR;
-  c.height = cssH * DPR;
+  // read per call, not once at module load: browser zoom / moving to a
+  // different-DPI monitor changes devicePixelRatio, and the resize re-init
+  // must pick up the new value or every canvas renders blurry
+  const dpr = window.devicePixelRatio || 1;
+  c.width = cssW * dpr;
+  c.height = cssH * dpr;
   c.style.width = cssW + "px";
   c.style.height = cssH + "px";
   const ctx = c.getContext("2d");
-  ctx.scale(DPR, DPR);
+  ctx.scale(dpr, dpr);
   return { ctx, w: cssW, h: cssH };
 }
 
@@ -220,9 +222,9 @@ function roundRect(ctx, x, y, w, h, r) {
 }
 
 /* Live track map: the path driven so far this event, plus the car.
-   pts: [[worldX, worldZ], ...] with null entries as teleport breaks;
-   ext: {minX, maxX, minZ, maxZ}; car: {x, z, hx, hz} or null (hx/hz =
-   world heading unit vector, from yaw). */
+   pts: [[worldX, worldZ], ...] (teleports/new sessions reset the whole
+   path upstream); ext: {minX, maxX, minZ, maxZ}; car: {x, z, hx, hz} or
+   null (hx/hz = world heading unit vector, from yaw). */
 function drawLiveMap(g, pts, ext, car) {
   const { ctx, w, h } = g;
   ctx.clearRect(0, 0, w, h);
@@ -246,12 +248,8 @@ function drawLiveMap(g, pts, ext, car) {
   ctx.lineWidth = 2;
   ctx.lineJoin = "round";
   ctx.beginPath();
-  let move = true;
-  for (const p of pts) {
-    if (p === null) { move = true; continue; }
-    move ? ctx.moveTo(X(p[0]), Y(p[1])) : ctx.lineTo(X(p[0]), Y(p[1]));
-    move = false;
-  }
+  ctx.moveTo(X(pts[0][0]), Y(pts[0][1]));
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(X(pts[i][0]), Y(pts[i][1]));
   ctx.stroke();
 
   // where the recording began

--- a/run_desktop.py
+++ b/run_desktop.py
@@ -9,6 +9,7 @@ opens the dashboard in the default browser. Running from source works too:
 from __future__ import annotations
 
 import os
+import socket
 import threading
 import webbrowser
 
@@ -20,6 +21,18 @@ def _default_data_dir() -> str:
     """Per-user data dir: %LOCALAPPDATA%\\LapScope on Windows, ~/.lapscope elsewhere."""
     base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
     return os.path.join(base, "LapScope")
+
+
+def _http_port_in_use() -> bool:
+    """Pre-check the HTTP port the way app/main.py guards the UDP port: if
+    uvicorn's bind fails it SystemExits, which slams the console shut on a
+    double-clicked exe before the user can read anything."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((HTTP_HOST, HTTP_PORT))
+        except OSError:
+            return True
+    return False
 
 
 def main() -> None:
@@ -36,6 +49,14 @@ def main() -> None:
     from app.main import app
 
     url = f"http://{HTTP_HOST}:{HTTP_PORT}"
+    if _http_port_in_use():
+        print(f"LapScope v{__version__}: HTTP port {HTTP_PORT} is already in use - "
+              "another program (or a second LapScope window) has it.")
+        print(f"If LapScope is already running, its dashboard is at {url} - "
+              "close this window and use that one.")
+        input("Press Enter to close this window...")
+        return
+
     threading.Timer(1.5, lambda: webbrowser.open(url)).start()
 
     print(f"LapScope v{__version__} starting - dashboard at {url}")


### PR DESCRIPTION
Closes #12 (from the 2026-07-08 full-code audit).

## Changes

- **Second-window crash → readable message.** `run_desktop.py` pre-checks HTTP port 8000; when busy it prints what happened (and that the running instance's dashboard is at `127.0.0.1:8000`) and pauses for Enter before exiting, mirroring `app/main.py`'s UDP-port handling. Previously uvicorn's bind failure SystemExited and the console window vanished before it could be read.
- **Stale DPR.** `initCanvas` now reads `devicePixelRatio` per call instead of snapshotting it at module load, and the dashboard's resize handler re-inits **all five** canvases (RPM/friction/grip were never re-inited). Browser zoom or moving to a different-DPI monitor no longer leaves canvases blurry until reload.
- **`pickLap` hardening.** Rapid A/B clicks race their fetches — a response now only lands if its pick still owns the slot, so a stale response can't overwrite a newer one. A failed fetch untags the lap and shows a themed alert instead of dying as an unhandled rejection. Untagging lap A clears the map side panel and the color legend (they used to keep showing the removed lap's stats).
- **Dead code dropped.** The live map's null-as-teleport-break handling (`dashboard.js` feed + `gauges.js drawLiveMap`): nothing ever pushed `null` — teleports and new sessions reset the whole path, which is the documented behavior.

## Testing

- Port conflict exercised for real: occupied 8000 with a TCP listener, ran `python run_desktop.py` → actionable message, waits for Enter, exit code 0.
- In the browser (source run on a scratch DB): forced an out-of-order lap-data response (newer pick wins, state consistent), a rejected fetch (alert + untag, no unhandled rejection), untag-A (side panel + legend clear), an emulated DPR change + resize (all five canvases rescale ×2), and a simulator sprint drawing the live track map with zero console errors.
- `pytest -q` 22 passed; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)