### PR TITLE
fix(recorder): jump landings are no longer flagged as contact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,14 +193,26 @@ All the rules exist because some real behavior broke a naive version:
 - Dirty-lap inference: rewind = lap clock below its high-water mark while
   distance doesn't grow (per-frame comparison misses gradual scrubs — that bug
   shipped once); contact = ground-plane |accel| ≥ 45 m/s². Stored as
-  `laps.flags` ("rewind,contact"). **Known contact-flag limits (real
-  cross-country, session 55):** hard jump-landings trip it (false positives —
-  roughly half of that race's spikes were landings, not the AI bumps they looked
-  like), and light Rivals wall-scrapes stay below the threshold (false negatives;
-  there is no lap-invalidated packet field to cross-check against). Improving
-  both is tracked in TODO.md ("Contact & lap-invalidation detection"). Flags
-  reset when a lap re-anchors (the WTA launch, a mid-session lap-timer start):
-  pre-launch junk frames must not dirty lap 1.
+  `laps.flags` ("rewind,contact"). **Jump landings are excused:** a spike while
+  airborne (all four `NormalizedSuspensionTravel` < 0.15 **and** all four
+  `TireCombinedSlip` < 0.05 for ≥ 0.12 s — in flight wheels hang at full droop
+  with zero tire force) or within 0.35 s of touchdown is a landing, not contact
+  (`AIRBORNE_*` / `LANDING_GRACE_S` in laps.py, mirrored in dashboard.js).
+  Calibrated on real cross-country (session 55: 5 of 12 spikes were landings —
+  touchdown compresses the suspension 1–2 frames *before* the spike, and
+  suspension drifts up to ~0.11 mid-flight, hence the loose thresholds and the
+  grace window; verified to change nothing on circuit sessions 5/6/35).
+  `/laps/{id}/data` tags collision bursts `landing: true/false` the same way —
+  the analysis map draws landings amber, the Contacts stat counts only real
+  ones. **Known remaining limit:** light Rivals wall-scrapes stay below the
+  threshold (false negatives; there is no lap-invalidated packet field to
+  cross-check against) — tracked in TODO.md ("Contact & lap-invalidation
+  detection"). A wall hit inside the 0.35 s post-landing grace is also excused
+  (accepted trade-off). Flags reset when a lap re-anchors (the WTA launch, a
+  mid-session lap-timer start): pre-launch junk frames must not dirty lap 1.
+  Test-fixture gotcha: `empty_fields()` zeroes suspension and slip, which
+  reads as *airborne* — hand-built test frames must set grounded values or
+  every contact spike gets excused (Driver in test_tracker.py does).
 - Routes are fingerprinted (start pos within 80 m + length within 5%) and named
   once by the user; names apply to every session on the route.
 - Sessions with zero completed laps/runs are discarded at close and again at
@@ -268,5 +280,6 @@ a row here, a test, and usually a simulator flag.
 | Sprint, stream cut at line | `--sprint 60 --cut` | session kept, single run ≈60 s flagged `cutoff`, route assigned |
 | World Time Attack | `--wta 3` | launch + 3 geometric laps + distance-reset finish, no post-finish phantom lap |
 | WTA, stream cut at the line | `--wta 3 --cut` | 3 geometric laps, last flagged `cutoff` (pending crossing finalized at session end), no phantom lap |
-| Jumps in 3D | `--sprint 75 --jumps` (or any + `--jumps`) | 3D map scale sane, spikes capped |
+| Jumps in 3D | `--sprint 75 --jumps` (or any + `--jumps`) | 3D map scale sane, spikes capped, run NOT flagged `contact` (landings excused) |
+| Landing vs contact | `--duration 180 --dirty --jumps` | lap 2 `contact` (wall hit), all other laps clean despite hard jump landings; `/laps/{id}/data` tags landing bursts `landing: true` (amber on the map) |
 | Race-mode gating | `--freeroam 35 --race 3` | chip FREE ROAM then RACE MODE; timer dashed in free roam; live map draws the race only |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,10 +194,13 @@ assert them here.
   `CLASS_COLORS` (common.js).
 - Teleport threshold 250 m: `WTA_TELEPORT_JUMP` (laps.py) = live-map jump reset
   (dashboard.js) = `POS_JUMP` (inspect_session.py).
-- Contact spike threshold: `IMPACT_ACCEL` (laps.py) drives both the per-lap
-  `contact` flag and the map collision markers — the `/laps/{id}/data`
-  endpoint imports it; `dashboard.js` duplicates it as `IMPACT_ACCEL` for the
-  live map (keep the two in lockstep).
+- Contact spike threshold + landing discrimination: `IMPACT_ACCEL`,
+  `AIRBORNE_SUSP_MAX`, `AIRBORNE_SLIP_MAX`, `AIRBORNE_MIN_S` and
+  `LANDING_GRACE_S` (laps.py) drive the per-lap `contact` flag and the map
+  collision markers (spikes while airborne / just after touchdown are jump
+  landings, not contact) — the `/laps/{id}/data` endpoint imports them and
+  tags each collision `landing: true/false`; `dashboard.js` duplicates all
+  five constants for the live map (keep the two in lockstep).
 - `RT_FREEZE_SECONDS` (laps.py) = the same constant in inspect_session.py.
 - Packet layout: `_STRUCT` and `FIELDS` in packet.py must stay in lockstep
   (asserted by the module self-test).

--- a/TODO.md
+++ b/TODO.md
@@ -127,15 +127,14 @@ the build. Playground Games ships new cars → new ordinals, so it goes stale.
 ## Contact & lap-invalidation detection (accuracy)
 
 The `contact` 💥 flag is a ground-plane accel spike (`IMPACT_ACCEL` = 45 m/s²).
-Real cross-country data (session 55) shows it is both too eager and too blind:
+Real cross-country data (session 55) showed it was both too eager and too blind:
 
-- **False positives: hard jump-landings flagged as contact.** Cross-country is
-  full of big jumps; landing hard trips the ground-plane threshold even though
-  it isn't a wall/car hit. On session 55 roughly half of ~12 contact markers
-  were landings, not the AI bumps they looked like. Idea: detect the airborne
-  phase preceding a spike (all wheels unloaded / suspension at full droop / no
-  tire load for several frames) and classify the following spike as a landing,
-  not contact.
+- ✅ **False positives: hard jump-landings flagged as contact.** Fixed: a spike
+  while airborne (all wheels at full droop + zero tire force for ≥ 0.12 s) or
+  within 0.35 s of touchdown is classified as a landing — no `contact` flag,
+  amber (not red) marker on the analysis map, excluded from the Contacts count.
+  Calibrated on session 55 (5 of its 12 spikes were landings) and verified to
+  leave circuit sessions untouched; old recordings pick it up via Reprocess.
 - **Manual session editing.** Let the user curate a recording — dismiss/ignore
   specific contact markers on the map, re-tag, or trim — for when the auto
   detector is wrong. Pairs with the analysis-map layer toggles in the settings

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -12,7 +12,8 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from .. import __version__
-from ..recorder.laps import IMPACT_ACCEL
+from ..recorder.laps import (AIRBORNE_MIN_S, AIRBORNE_SLIP_MAX,
+                             AIRBORNE_SUSP_MAX, IMPACT_ACCEL, LANDING_GRACE_S)
 from ..recorder.reprocess import reprocess_session
 from ..telemetry.packet import parse
 
@@ -244,24 +245,44 @@ def lap_data(
     # consecutive over-threshold frames into one event and keep its peak. Run
     # on the full-resolution kept trace so a one-frame spike is never decimated
     # away. World coords are returned so the map projects them like any point.
+    # Spikes while airborne or right after touchdown are jump landings, not
+    # contact (same classification as the recorder) - tagged, not dropped, so
+    # the map can still show where a jump bottomed out.
     collisions: list[dict] = []
     peak: tuple | None = None  # (g, d, frame) of the current impact burst
-    for t, d, p in kept:
-        g = math.hypot(p["accel_x"], p["accel_z"])
-        if g >= IMPACT_ACCEL:
-            if peak is None or g > peak[0]:
-                peak = (g, d, p)
-        elif peak is not None:
-            g0, d0, p0 = peak
-            collisions.append({"x": round(p0["pos_x"], 2), "y": round(p0["pos_y"], 2),
-                               "z": round(p0["pos_z"], 2), "dist": round(d0 - start_dist, 2),
-                               "g": round(g0 / 9.80665, 2)})
-            peak = None
-    if peak is not None:  # impact ran to the last kept frame
+    burst_landing = True       # all frames of the burst classified as landing
+    air_since: float | None = None
+    grace_until = 0.0
+
+    def emit(peak: tuple, landing: bool) -> None:
         g0, d0, p0 = peak
         collisions.append({"x": round(p0["pos_x"], 2), "y": round(p0["pos_y"], 2),
                            "z": round(p0["pos_z"], 2), "dist": round(d0 - start_dist, 2),
-                           "g": round(g0 / 9.80665, 2)})
+                           "g": round(g0 / 9.80665, 2), "landing": landing})
+
+    for t, d, p in kept:
+        airborne = (all(s < AIRBORNE_SUSP_MAX for s in p["norm_susp_travel"])
+                    and all(s < AIRBORNE_SLIP_MAX for s in p["tire_combined_slip"]))
+        if airborne:
+            if air_since is None:
+                air_since = t
+        else:
+            if air_since is not None and t - air_since >= AIRBORNE_MIN_S:
+                grace_until = t + LANDING_GRACE_S
+            air_since = None
+        flying = air_since is not None and t - air_since >= AIRBORNE_MIN_S
+        g = math.hypot(p["accel_x"], p["accel_z"])
+        if g >= IMPACT_ACCEL:
+            if peak is None:
+                peak, burst_landing = (g, d, p), True
+            elif g > peak[0]:
+                peak = (g, d, p)
+            burst_landing = burst_landing and (flying or t < grace_until)
+        elif peak is not None:
+            emit(peak, burst_landing)
+            peak = None
+    if peak is not None:  # impact ran to the last kept frame
+        emit(peak, burst_landing)
 
     stride = max(1, len(kept) // max_points)
     dist: list[float] = []

--- a/app/recorder/laps.py
+++ b/app/recorder/laps.py
@@ -86,7 +86,9 @@ The packet carries no "lap invalidated" flag, so lap dirtiness is inferred:
   does that - time only runs forward), corroborated by DistanceTraveled
   not increasing;
 - contact: a ground-plane acceleration spike far beyond what tires can
-  generate (a wall or solid obstacle).
+  generate (a wall or solid obstacle). A spike while airborne or right
+  after touchdown is the landing of a jump, not contact - cross-country
+  is full of those - so it is logged but never flags the lap.
 Flags are stored per lap ("rewind,contact") and shown in the lap table.
 
 All methods run on the asyncio event-loop thread.
@@ -108,6 +110,21 @@ PUDDLE_DEPTH_MIN = 0.03       # any wheel deeper than this counts as a wet frame
 WET_FRAME_FRACTION = 0.02     # fraction of wet frames to auto-tag "wet"
 REWIND_TIME_JUMP = 0.5        # lap clock going back by this much = rewind
 IMPACT_ACCEL = 45.0           # m/s^2 in the ground plane (~4.6 g) = contact
+
+# Airborne / jump-landing discrimination (verified on real cross-country,
+# session 55: 5 of its 12 contact spikes were hard jump-landings). In flight
+# every wheel hangs at full droop with zero tire force; on the ground even a
+# coasting car shows load on some wheel. Touchdown compresses the suspension a
+# frame or two BEFORE the accel spike crosses IMPACT_ACCEL, so a spike counts
+# as the landing for a short grace window after the flight ends, not only
+# while airborne. Mirrored in dashboard.js for the live map (keep in lockstep).
+AIRBORNE_SUSP_MAX = 0.15      # all NormalizedSuspensionTravel below this
+                              # (0 = full stretch; ~0.1 drift seen pre-landing)
+AIRBORNE_SLIP_MAX = 0.05      # and all TireCombinedSlip below this = no tire
+                              # touches the ground (driving shows >= ~0.1)
+AIRBORNE_MIN_S = 0.12         # unloaded this long = a real flight, not a crest
+LANDING_GRACE_S = 0.35        # spikes this soon after touchdown = the landing
+                              # (real gaps measured at 0.02-0.07 s)
 RT_FREEZE_SECONDS = 1.5       # frozen race clock for this long = event finished
 FINISH_MIN_RT = 5.0           # ignore freezes before the clock really ran
 PTP_MIN_RUN_TIME = 10.0       # shortest believable point-to-point run
@@ -179,6 +196,9 @@ class SessionTracker:
         self._wta_best: tuple | None = None  # (d, t, rt, dist, x, z) closest pass
         self._wta_prev_pos: tuple[float, float] | None = None
         self._puddle_frames = 0
+        self._air_since: float | None = None   # start of the current flight
+        self._landing_grace_until = 0.0        # spikes before this t = landing
+        self._over_impact = False              # inside a spike burst (log once)
         self._route_assigned = False
         self._session_start_t = 0.0
         self._diag_first_dist: float | None = None
@@ -233,12 +253,30 @@ class SessionTracker:
             self._gridded = True
         if any(d > PUDDLE_DEPTH_MIN for d in frame["wheel_in_puddle"]):
             self._puddle_frames += 1
-        if math.hypot(frame["accel_x"], frame["accel_z"]) >= IMPACT_ACCEL:
-            if "contact" not in self._lap_flags:
-                log.info("Session %s: contact spike (%.0f m/s^2), flagging lap",
-                         self.session_id,
-                         math.hypot(frame["accel_x"], frame["accel_z"]))
-            self._lap_flags.add("contact")
+        airborne = (all(s < AIRBORNE_SUSP_MAX for s in frame["norm_susp_travel"])
+                    and all(s < AIRBORNE_SLIP_MAX for s in frame["tire_combined_slip"]))
+        if airborne:
+            if self._air_since is None:
+                self._air_since = t
+        else:
+            if self._air_since is not None and t - self._air_since >= AIRBORNE_MIN_S:
+                self._landing_grace_until = t + LANDING_GRACE_S
+            self._air_since = None
+        flying = self._air_since is not None and t - self._air_since >= AIRBORNE_MIN_S
+        g = math.hypot(frame["accel_x"], frame["accel_z"])
+        if g >= IMPACT_ACCEL:
+            if flying or t < self._landing_grace_until:
+                if not self._over_impact:
+                    log.info("Session %s: jump landing (%.0f m/s^2) - not contact",
+                             self.session_id, g)
+            else:
+                if "contact" not in self._lap_flags:
+                    log.info("Session %s: contact spike (%.0f m/s^2), flagging lap",
+                             self.session_id, g)
+                self._lap_flags.add("contact")
+            self._over_impact = True
+        else:
+            self._over_impact = False
         delta = self._lap_logic(t, frame)
         if t - self._last_flush >= FLUSH_INTERVAL:
             self.flush()
@@ -313,6 +351,9 @@ class SessionTracker:
         self._wta_best = None
         self._wta_prev_pos = None
         self._puddle_frames = 0
+        self._air_since = None
+        self._landing_grace_until = 0.0
+        self._over_impact = False
         self._route_assigned = False
         self._session_start_t = t
         self._diag_first_dist = frame["distance_traveled"]
@@ -419,6 +460,9 @@ class SessionTracker:
         self._wta_inside = False
         self._wta_best = None
         self._wta_prev_pos = None
+        self._air_since = None
+        self._landing_grace_until = 0.0
+        self._over_impact = False
         self._lap_flags = set()
 
     def _point_to_point_run_time(self) -> float | None:

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -515,33 +515,40 @@ function drawMap() {
 
     const side = $("#map-side");
     const lapMeta = state.laps.find((l) => l.id === state.lapA);
+    // landings (spikes on jump touchdowns) are shown but not counted as contact
+    const contacts = (A.collisions || []).filter((h) => !h.landing).length;
+    const landings = (A.collisions?.length || 0) - contacts;
     side.innerHTML = `<div class="lap-grid" style="text-align:left">
       <div><div class="label">Lap A</div><div class="value">${fmtLap(lapMeta?.lap_time)}</div></div>
       <div><div class="label">Lap B</div><div class="value">${fmtLap(state.laps.find((l) => l.id === state.lapB)?.lap_time)}</div></div>
       <div><div class="label">Samples</div><div class="value">${A.n_frames}</div></div>
       <div><div class="label">Driven</div><div class="value">${distFromM(drivenM).toFixed(2)} ${distUnit()}</div></div>
       <div><div class="label">Elevation range</div><div class="value">${yRange > 0.3 ? yRange.toFixed(0) + " m" : "flat"}</div></div>
-      <div><div class="label">Contacts</div><div class="value">${(A.collisions?.length || 0) ? `<span style="color:#ef4444">${A.collisions.length}</span>` : "0"}</div></div>
+      <div><div class="label">Contacts</div><div class="value">${contacts ? `<span style="color:#ef4444">${contacts}</span>` : "0"}${landings ? `<span style="color:#f59e0b;font-size:0.9rem" title="${landings} hard jump landing${landings > 1 ? "s" : ""} — not contact"> +${landings} 🛬</span>` : ""}</div></div>
     </div>`;
   }
 
   // collision points (contact spikes) as red bursts, over the ribbon so
   // they read against any speed/slip color. B's are dimmer, like its line.
-  const drawHits = (d, fill, r) => {
+  // Jump landings (h.landing, classified server-side) draw amber and smaller:
+  // worth seeing where a jump bottomed out, but they aren't contact.
+  const drawHits = (d, fill, landFill, r) => {
     if (!d || !d.collisions) return;
-    for (const h of d.collisions) {
+    for (const h of [...d.collisions].sort((a, b) => (b.landing ? 1 : 0) - (a.landing ? 1 : 0))) {
       const [X, Y] = P(h.x, h.y ?? 0, h.z, false);
+      const color = h.landing ? landFill : fill;
+      const rad = h.landing ? r * 0.75 : r;
       ctx.save();
       ctx.strokeStyle = "#fff";
       ctx.lineWidth = 1.5;
-      ctx.fillStyle = fill;
-      ctx.shadowColor = fill;
+      ctx.fillStyle = color;
+      ctx.shadowColor = color;
       ctx.shadowBlur = 8;
       // 4-point spark
       ctx.beginPath();
       for (let k = 0; k < 8; k++) {
         const a = (k * Math.PI) / 4;
-        const rr = k % 2 ? r * 0.4 : r;
+        const rr = k % 2 ? rad * 0.4 : rad;
         const px = X + Math.cos(a) * rr, py = Y + Math.sin(a) * rr;
         k === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
       }
@@ -552,8 +559,8 @@ function drawMap() {
     }
   };
   if (getSettings().contactLayer) {
-    drawHits(B, "#7f5b5b", 6);
-    drawHits(A, "#ef4444", 7);
+    drawHits(B, "#7f5b5b", "#7f6f4b", 6);
+    drawHits(A, "#ef4444", "#f59e0b", 7);
   }
 
   // cache the finished frame + projection for the chart-cursor marker

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -28,9 +28,15 @@ const shiftLights = document.querySelectorAll("#shift-lights i");
 /* live track map: path of the current session, thinned adaptively so long
    drives stay cheap to redraw at display refresh rate */
 const LIVEMAP_CAP = 4000;
-// ground-plane acceleration (m/s^2) that counts as a contact/collision;
-// mirrors IMPACT_ACCEL in app/recorder/laps.py (keep the two in lockstep).
+// ground-plane acceleration (m/s^2) that counts as a contact/collision, plus
+// the airborne/jump-landing discrimination (a spike while airborne or right
+// after touchdown is a landing, not contact); mirrors IMPACT_ACCEL /
+// AIRBORNE_* / LANDING_GRACE_S in app/recorder/laps.py (keep in lockstep).
 const IMPACT_ACCEL = 45;
+const AIRBORNE_SUSP_MAX = 0.15;
+const AIRBORNE_SLIP_MAX = 0.05;
+const AIRBORNE_MIN_S = 0.12;
+const LANDING_GRACE_S = 0.35;
 const liveMap = {
   pts: [],         // [x, z] world points
   last: null,      // last stored point
@@ -39,6 +45,8 @@ const liveMap = {
   minX: Infinity, maxX: -Infinity, minZ: Infinity, maxZ: -Infinity,
   hits: [],        // [x, z] world points where a contact spike fired
   overImpact: false, // above the threshold last frame (edge-detect one hit/impact)
+  airSince: null,  // when the current all-wheels-unloaded stretch began
+  graceUntil: 0,   // spikes before this time are jump landings, not contact
 };
 
 function resetLiveMap(sessionId) {
@@ -50,6 +58,8 @@ function resetLiveMap(sessionId) {
   liveMap.maxX = liveMap.maxZ = -Infinity;
   liveMap.hits = [];
   liveMap.overImpact = false;
+  liveMap.airSince = null;
+  liveMap.graceUntil = 0;
 }
 
 // One marker per impact: register on the rising edge only, so grinding a wall
@@ -64,10 +74,24 @@ function mapActive(f) {
 function feedCollision(f) {
   if (f.session_id == null || !mapActive(f) || f.session_id !== liveMap.session) {
     liveMap.overImpact = false;
+    liveMap.airSince = null;
     return;
   }
+  const t = f._t;
+  const airborne = f.norm_susp_travel.every((s) => s < AIRBORNE_SUSP_MAX)
+    && f.tire_combined_slip.every((s) => s < AIRBORNE_SLIP_MAX);
+  if (airborne) {
+    if (liveMap.airSince == null) liveMap.airSince = t;
+  } else {
+    if (liveMap.airSince != null && t - liveMap.airSince >= AIRBORNE_MIN_S)
+      liveMap.graceUntil = t + LANDING_GRACE_S;
+    liveMap.airSince = null;
+  }
+  const flying = liveMap.airSince != null && t - liveMap.airSince >= AIRBORNE_MIN_S;
   if (Math.hypot(f.accel_x, f.accel_z) >= IMPACT_ACCEL) {
-    if (!liveMap.overImpact) liveMap.hits.push([f.pos_x, f.pos_z]);
+    // jump landings (spike while airborne / just after touchdown) draw no spark
+    if (!liveMap.overImpact && !(flying || t < liveMap.graceUntil))
+      liveMap.hits.push([f.pos_x, f.pos_z]);
     liveMap.overImpact = true;
   } else {
     liveMap.overImpact = false;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,6 +56,30 @@ def test_lap_time_channel_kept_when_lap_clock_alive(tmp_path):
     assert any(v > 0.5 for v in data["channels"]["lap_time"])
 
 
+def test_collisions_tag_landings_but_keep_wall_hits(tmp_path):
+    """/laps/{id}/data classifies each collision burst: jump landings carry
+    landing=true (drawn amber, not counted as contact), wall hits
+    landing=false. --dirty --jumps has both on lap 2 and only landings on
+    the other laps."""
+    from app.api.routes import lap_data
+
+    def scenario(sim):
+        sim.event(180, "dirty with jumps", dirty=True)
+        sim.race_off()
+
+    store = run(scenario, tmp_path, jumps=True)
+    laps = completed_laps(store, sessions(store)[0]["id"])
+    by_number = {lap["lap_number"]: lap for lap in laps}
+
+    wall_lap = lap_data(by_number[1]["id"], _request_for(store), "speed_kmh", 500)
+    kinds = {h["landing"] for h in wall_lap["collisions"]}
+    assert kinds == {True, False}  # the wall hit and two jump landings
+
+    clean_lap = lap_data(by_number[0]["id"], _request_for(store), "speed_kmh", 500)
+    assert clean_lap["collisions"]  # the jumps did register...
+    assert all(h["landing"] for h in clean_lap["collisions"])  # ...as landings
+
+
 def test_session_name_patch_sets_and_clears(tmp_path):
     """``name: ""`` must clear the custom name back to NULL so display_name
     falls back to route/date, and a PATCH without name must leave it alone.

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -176,7 +176,9 @@ def test_wta_cut_dead_at_line(tmp_path):
 
 def test_jumps_do_not_break_a_point_to_point_run(tmp_path):
     """--sprint 75 --jumps: cross-country-style elevation spikes still record
-    a single clean run (3D-map scaling is a frontend concern)."""
+    a single clean run (3D-map scaling is a frontend concern). The jumps go
+    airborne and land with spikes past IMPACT_ACCEL - the landing classifier
+    must keep the run free of the contact flag."""
     def scenario(sim):
         sim.sprint(75)
         sim.race_off()
@@ -185,4 +187,27 @@ def test_jumps_do_not_break_a_point_to_point_run(tmp_path):
     ss = sessions(store)
 
     assert len(ss) == 1
-    assert len(completed_laps(store, ss[0]["id"])) == 1
+    laps = completed_laps(store, ss[0]["id"])
+    assert len(laps) == 1
+    assert "contact" not in flags_of(laps[0])
+
+
+def test_jump_landings_clean_but_wall_contact_still_flags(tmp_path):
+    """--duration 180 --dirty --jumps: every lap flies two bumps and lands
+    hard (ground-plane spikes past the contact threshold) - those must NOT
+    flag contact; the wall hit injected on lap 2 still must."""
+    def scenario(sim):
+        sim.event(180, "dirty with jumps", dirty=True)
+        sim.race_off()
+
+    store = run(scenario, tmp_path, jumps=True)
+    ss = sessions(store)
+
+    assert len(ss) == 1
+    by_number = {lap["lap_number"]: flags_of(lap)
+                 for lap in completed_laps(store, ss[0]["id"])}
+    assert len(by_number) >= 3
+    assert "contact" in by_number.get(1, "")  # the real wall hit still flags
+    for n, fl in by_number.items():
+        if n != 1:  # every other lap only landed jumps - clean
+            assert "contact" not in fl, f"lap {n} flagged by a jump landing: {fl}"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -24,7 +24,11 @@ class Driver:
         self.tracker = SessionTracker(self.store)
         self.f = empty_fields()
         self.f.update(is_race_on=1, car_ordinal=1, car_class=6, car_pi=900,
-                      drivetrain_type=2)
+                      drivetrain_type=2,
+                      # wheels on the ground: all-zero suspension + slip (the
+                      # empty_fields default) reads as airborne to the landing
+                      # classifier, which would excuse every contact spike
+                      norm_susp_travel=[0.5] * 4, tire_combined_slip=[0.3] * 4)
         self.t = 0.0
 
     def send(self, **kw) -> dict:
@@ -96,6 +100,63 @@ def test_mid_session_reanchor_clears_flags(tmp_path):
     assert len(timed) == 1
     assert timed[0]["lap_time"] == 10.0
     assert "contact" not in (timed[0]["flags"] or "")
+
+
+GROUND = dict(norm_susp_travel=[0.5] * 4, tire_combined_slip=[0.3] * 4, accel_x=0.0)
+AIR = dict(norm_susp_travel=[0.0] * 4, tire_combined_slip=[0.0] * 4, accel_x=0.0)
+
+
+def drive(d: Driver, n: int, **kw) -> None:
+    """n frames of steady driving: lap clock and odometer advance."""
+    for _ in range(n):
+        d.send(current_lap=d.f["current_lap"] + 1 / 60,
+               distance_traveled=d.f["distance_traveled"] + 1.0,
+               speed=60.0, **kw)
+
+
+def lap_flags_after(d: Driver) -> str:
+    """Cross the line to complete lap 1, then return its flags."""
+    d.send(lap_number=1, current_lap=0.0, last_lap=6.0, speed=60.0, **GROUND)
+    drive(d, 60, **GROUND)
+    timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
+    assert len(timed) >= 1
+    return timed[0]["flags"] or ""
+
+
+def test_landing_spike_after_flight_is_not_contact(tmp_path):
+    """A contact-threshold spike right after a real flight (all wheels
+    unloaded, no tire force, >= AIRBORNE_MIN_S) is the landing of a jump -
+    the lap stays clean. Matches real cross-country captures (session 55):
+    touchdown compresses the suspension a frame or two before the spike."""
+    d = Driver(tmp_path)
+    drive(d, 120, **GROUND)                          # 2 s on the ground
+    drive(d, 30, **AIR)                              # 0.5 s flight
+    drive(d, 2, **{**GROUND, "accel_x": 110.0})      # touchdown spike, loaded
+    drive(d, 120, **GROUND)
+    assert "contact" not in lap_flags_after(d)
+
+
+def test_short_hop_spike_still_flags_contact(tmp_path):
+    """Wheels unloaded for only a few frames (a crest, not a flight) does not
+    excuse a spike: still contact."""
+    d = Driver(tmp_path)
+    drive(d, 120, **GROUND)
+    drive(d, 4, **AIR)                               # 0.07 s < AIRBORNE_MIN_S
+    drive(d, 2, **{**GROUND, "accel_x": 110.0})
+    drive(d, 120, **GROUND)
+    assert "contact" in lap_flags_after(d)
+
+
+def test_spike_after_landing_grace_still_flags_contact(tmp_path):
+    """A spike well after touchdown (past LANDING_GRACE_S) is real contact -
+    e.g. landing a jump, then hitting a rock two seconds later."""
+    d = Driver(tmp_path)
+    drive(d, 120, **GROUND)
+    drive(d, 30, **AIR)                              # a real flight...
+    drive(d, 60, **GROUND)                           # ...landed 1 s ago
+    drive(d, 2, **{**GROUND, "accel_x": 110.0})
+    drive(d, 120, **GROUND)
+    assert "contact" in lap_flags_after(d)
 
 
 def test_race_mode_drops_at_lastlap_finish(tmp_path):

--- a/tools/simulator.py
+++ b/tools/simulator.py
@@ -138,6 +138,9 @@ class Sim:
     pace = 1.0
     lon_a = 0.0
     impact_frames = 0
+    air_frames = 0     # jump flight in progress (all wheels unloaded)
+    land_frames = 0    # touchdown jolt frames right after a flight
+    _prev_sp = None
 
     def _send(self, race_time: float, lap_no: int, cur_lap: float,
               last: float, best: float) -> None:
@@ -156,8 +159,36 @@ class Sim:
         if self.impact_frames > 0:  # wall contact: brief violent lateral spike
             self.impact_frames -= 1
             lat_a += 60.0
+        # jumps: crossing a bump crest launches the car (like real
+        # cross-country, all wheels at full droop with zero tire force), and
+        # touchdown slams the suspension with a ground-plane jolt well past
+        # the recorder's contact threshold - which it must classify as a
+        # landing, not contact
+        airborne, vert_a = False, 0.2
+        if JUMPS:
+            sp = self.s % PERIMETER
+            if self.air_frames == 0 and self.land_frames == 0 and self._prev_sp is not None:
+                # crest crossed this frame (wrap = sp collapsed by ~a lap;
+                # a rewind scrub moves backwards in small steps and must not
+                # launch the car)
+                wrapped = self._prev_sp - sp > PERIMETER / 2
+                for c, _w, _h in JUMP_BUMPS:
+                    if ((self._prev_sp < c <= sp)
+                            or (wrapped and (self._prev_sp < c or c <= sp))):
+                        self.air_frames = int(round(0.4 / self.dt))
+            self._prev_sp = sp
+            if self.air_frames > 0:
+                self.air_frames -= 1
+                airborne = True
+                lat_a, vert_a = 0.0, -12.0  # free fall, no tire grip
+                if self.air_frames == 0:
+                    self.land_frames = 2
+            elif self.land_frames > 0:
+                self.land_frames -= 1
+                lat_a += 75.0  # touchdown jolt in the ground plane
+                vert_a = 160.0
         grip_used = math.hypot(lat_a / GRIP_LAT, self.lon_a / BRAKE_MAX)
-        slip = max(0.0, grip_used + random.uniform(-0.05, 0.05))
+        slip = 0.0 if airborne else max(0.0, grip_used + random.uniform(-0.05, 0.05))
 
         gear = next((i + 1 for i, top in enumerate(GEAR_TOPS) if self.v <= top), 6)
         lo = GEAR_TOPS[gear - 2] if gear >= 2 else 0.0
@@ -173,19 +204,20 @@ class Sim:
         f.update(
             timestamp_ms=int((time.monotonic() - self.t0) * 1000) & 0xFFFFFFFF,
             current_engine_rpm=rpm,
-            accel_x=lat_a, accel_y=0.2, accel_z=self.lon_a,
+            accel_x=lat_a, accel_y=vert_a, accel_z=self.lon_a,
             # like the real game: Velocity is car-local (~(0, 0, speed)),
             # and the car moves along (sin yaw, cos yaw) in world X/Z -
             # here movement is (cos heading, sin heading), so yaw = pi/2 - heading
             vel_x=0.0, vel_z=self.v,
             ang_vel_y=self.v * curv, yaw=math.pi / 2 - heading,
-            norm_susp_travel=[min(1.0, 0.45 + 0.3 * abs(lat_a) / GRIP_LAT + 0.1 * random.random())] * 4,
+            norm_susp_travel=[0.0] * 4 if airborne else
+                [min(1.0, 0.45 + 0.3 * abs(lat_a) / GRIP_LAT + 0.1 * random.random())] * 4,
             tire_slip_ratio=[slip * 0.6] * 4,
             wheel_rotation_speed=[self.v / 0.33] * 4,
             wheel_in_puddle=puddle,
             tire_slip_angle=[slip * front_bias, slip * front_bias, slip * 0.9, slip * 0.9],
             tire_combined_slip=[slip * front_bias, slip * front_bias, slip * 0.92, slip * 0.92],
-            susp_travel_meters=[0.06] * 4,
+            susp_travel_meters=[-0.08] * 4 if airborne else [0.06] * 4,
             pos_x=x, pos_y=track_elevation(self.s), pos_z=z,
             speed=self.v, power=torque * rpm * math.tau / 60, torque=torque,
             tire_temp=[160 + 90 * slip + random.uniform(-3, 3) for _ in range(4)],
@@ -376,6 +408,10 @@ class Sim:
             timestamp_ms=int((time.monotonic() - self.t0) * 1000) & 0xFFFFFFFF,
             current_engine_rpm=IDLE_RPM, accel_x=0.0, accel_z=0.0,
             vel_x=0.0, vel_z=0.0, ang_vel_y=0.0,
+            # a parked car sits ON its suspension - never zero like empty
+            # fields, or it would read as airborne to the landing classifier
+            norm_susp_travel=[0.45] * 4, tire_combined_slip=[0.0] * 4,
+            susp_travel_meters=[0.06] * 4,
             pos_x=x, pos_y=105.0, pos_z=z,
             speed=0.0, power=0.0, torque=0.0, boost=0.0,
             distance_traveled=0.0, best_lap=0.0, last_lap=0.0,


### PR DESCRIPTION
Lands the first bullet of TODO.md's **Contact & lap-invalidation detection (accuracy)**: hard jump landings no longer read as wall/car contact.

## Problem

The `contact` 💥 flag was a bare ground-plane accel test (`IMPACT_ACCEL` = 45 m/s²). On real cross-country (session 55), 5 of 12 "contact" spikes were actually hard jump landings — false lap flags and bogus collision markers on the map.

## The signature (from real captures)

- In flight, all four `NormalizedSuspensionTravel` sit at full droop (drifting up to ~0.11 just before touchdown) and all four `TireCombinedSlip` are exactly 0 — the game zeroes slip for unloaded wheels even at full throttle.
- Touchdown compresses the suspension **1–2 frames before** the accel spike crosses the threshold (measured gaps 0.02–0.07 s), so airborne-at-spike alone catches nothing — a grace window after flight end is required.

A spike while airborne (all susp < 0.15 **and** all slip < 0.05 for ≥ 0.12 s) or within 0.35 s of touchdown is a **landing**: logged, never flagged. Everything else stays contact.

## Changes

- **Recorder** (`laps.py`): airborne/grace state machine ahead of the spike test; landings logged (`jump landing (78 m/s²) - not contact`), contact unchanged otherwise. Old recordings pick the fix up via **Reprocess**.
- **API** (`/laps/{id}/data`): each collision burst is tagged `landing: true/false` with the same state machine — landings are shown, not hidden.
- **Analysis map**: landings draw as smaller **amber** sparks vs red contact; the Contacts stat counts only real hits and shows `+N 🛬` when landings exist.
- **Live map** (`dashboard.js`): classifier constants mirrored (lockstep note in ARCHITECTURE.md); landing spikes draw no spark.
- **Simulator `--jumps`** now actually launches the car (unloaded wheels, zero slip, free fall, touchdown jolt past the threshold); parked frames got realistic loaded suspension — all-zero packet fields read as airborne, which would have silently defanged the existing contact-hygiene tests (noted in AGENTS.md).

## Validation

- Whole-DB replay through the new recorder: session 21 loses its two false `contact` flags (its only spikes were landings); circuit sessions 5/6/8/11/35 byte-identical flags; session 55 correctly **keeps** `contact` (7 real AI bumps remain) while its 5 landings become amber markers.
- Live end-to-end: simulator sprint with jumps against a running server — recorder logged 3 landings, lap finished flag-free, live map drew 0 sparks; analysis sidebar reads **Contacts 7 +5 🛬** on session 55.
- Tests: 3 new frame-exact tracker tests (flight / short-hop / grace-expiry), a dirty+jumps scenario (wall hit still flags, landings never do), an API landing-tag test. 30 passed, ruff clean.

Known accepted trade-off (documented in AGENTS.md): a genuine wall hit within 0.35 s of a landing is excused. Rivals light wall-scrape false negatives remain tracked in TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)