### PR TITLE
docs: GitHub wiki authored in-repo (docs/wiki + publish workflow); README polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/unrecognized_event.yml
+++ b/.github/ISSUE_TEMPLATE/unrecognized_event.yml
@@ -24,7 +24,8 @@ body:
            offer) the `data/telemetry.db` — the raw frames let us reproduce and
            add a test.
 
-        More on the workflow: the README "Troubleshooting" section and the Wiki.
+        Full walkthrough (incl. setting the flag for the exe and reading the
+        output): [Capturing an Unrecognized Event](https://github.com/darcane/LapScope/wiki/Capturing-an-Unrecognized-Event).
   - type: dropdown
     id: event-type
     attributes:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,45 @@
+# Mirrors docs/wiki/ to the GitHub wiki (github.com/<repo>/wiki).
+#
+# docs/wiki/ in this repo is the SOURCE OF TRUTH for the wiki: pages are
+# authored there, reviewed through normal PRs, and published here on merge.
+# Never edit the wiki directly on GitHub - this mirror deletes/overwrites
+# anything that isn't in docs/wiki/. Convention details: AGENTS.md.
+#
+# Auth: the default GITHUB_TOKEN (contents: write) can push to the .wiki.git
+# repo. If that push ever starts failing with a 403, create a PAT with repo
+# scope, store it as a WIKI_TOKEN secret, and swap it into the clone URL.
+# The wiki must exist (have >=1 page created via the UI) before the first run.
+
+name: Publish wiki
+
+on:
+  push:
+    branches: [main]
+    paths: ["docs/wiki/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mirror docs/wiki -> GitHub wiki
+        run: |
+          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" /tmp/wiki
+          rsync -a --delete --exclude '.git' docs/wiki/ /tmp/wiki/
+          cd /tmp/wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki already up to date."
+            exit 0
+          fi
+          git commit -m "Sync from docs/wiki @ ${GITHUB_SHA}"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,26 @@ and the hard-won behavioral facts that must not be re-derived or regressed.
    responsibilities, data flow, DB schema, API surface, WebSocket contract,
    concurrency rules, simulator flags, and the cross-file invariants that must
    stay in sync. Consult it before touching anything structural.
-3. **[README.md](README.md)** — user-facing: setup, in-game settings,
-   troubleshooting flows (no packets, unrecognized event types).
-4. **[TODO.md](TODO.md)** — open backlog and in-flight investigations.
+3. **[README.md](README.md)** — user-facing: setup, in-game settings, quick
+   troubleshooting. Kept deliberately basic — deep material goes on the wiki.
+4. **Wiki** (source: [docs/wiki/](docs/wiki/)) — user-facing deep dives:
+   Troubleshooting, Capturing-an-Unrecognized-Event, FH6-Data-Out-Packet,
+   Event-Detection (+ `_Sidebar`/`_Footer`). Mirrored to the GitHub wiki by
+   [.github/workflows/wiki.yml](.github/workflows/wiki.yml) on every merge to
+   `main`; `docs/wiki/` is the **source of truth — never edit the wiki on
+   GitHub**, the next sync overwrites it. Pages link each other wiki-style
+   (`[text](Page-Name)`, no `.md` — resolves only on the published wiki) and
+   link repo files/images by absolute URL
+   (`https://github.com/darcane/LapScope/blob/main/…`,
+   `https://raw.githubusercontent.com/darcane/LapScope/main/…`).
+5. **[TODO.md](TODO.md)** — open backlog and in-flight investigations.
 
-Keep all four current: a detection change usually touches this file's model
-section, a new endpoint/table belongs in ARCHITECTURE.md, a new user-visible
-feature in the README, and finished TODO items get pruned.
+Keep all five current: a detection change usually touches this file's model
+section **and** the wiki's Event-Detection page; a new endpoint/table belongs
+in ARCHITECTURE.md; a new user-visible feature in the README; a change to
+packet understanding, troubleshooting steps, or the capture workflow updates
+the matching `docs/wiki/` page **in the same PR**; finished TODO items get
+pruned.
 
 ## What this is
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,6 +138,10 @@ assert them here.
   ([requirements.txt](requirements.txt)).
 - [.claude/launch.json](.claude/launch.json): preview server runs
   `docker compose up` and owns the process.
+- [.github/workflows/wiki.yml](.github/workflows/wiki.yml): mirrors
+  [docs/wiki/](docs/wiki/) to the GitHub wiki on every merge to `main` that
+  touches it (plus manual dispatch). `docs/wiki/` is the source of truth —
+  direct wiki edits get overwritten by the next sync.
 
 ### Windows exe (plug-and-play build for normal users)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,13 @@ Read these before making non-trivial changes:
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — what lives where: file
   responsibilities, data flow, DB schema, API surface, and the cross-file
   invariants that must stay in sync.
-- **[README.md](README.md)** — user-facing setup, in-game settings, and
+- **[README.md](README.md)** — user-facing setup, in-game settings, and quick
   troubleshooting.
+- **The [Wiki](../../wiki)** — user-facing deep dives (troubleshooting, the
+  capture workflow, packet internals, event detection). Authored in
+  [docs/wiki/](docs/wiki/) and mirrored to the GitHub wiki on merge —
+  `docs/wiki/` is the source of truth, so wiki changes go through normal PRs;
+  never edit the wiki directly on GitHub.
 
 ## Development setup
 
@@ -59,9 +64,13 @@ lands on it except a green, reviewed PR.
 1. **Cut a branch off `main`.** Name it `feat/<short-desc>` for features or
    `fix/<short-desc>` for fixes.
 2. **Make your change**, keeping the docs in step:
-   - a detection change usually touches the AGENTS.md model section,
+   - a detection change usually touches the AGENTS.md model section **and** the
+     wiki's Event-Detection page,
    - a new endpoint/table belongs in ARCHITECTURE.md,
-   - a new user-visible feature belongs in the README.
+   - a new user-visible feature belongs in the README,
+   - changed packet facts, troubleshooting steps, or capture workflow update
+     the matching page under `docs/wiki/` (published to the GitHub wiki on
+     merge).
 3. **Add or update tests.** New detection behavior needs a scenario in
    `tools/simulator.py` and a matching headless assertion in
    `tests/test_scenarios.py`.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ the packet's elevation and is drag-to-rotate; the ✦ markers are detected conta
 
 ![Track map in 3D, drag-to-rotate](docs/media/track-map-3d.png)
 
+**Jumps, drawn as jumps** — takeoff ○, dashed flight line, touchdown ▸, an amber
+glow + impact ring on hard landings; the red ✦ is a real contact:
+
+![Jump glyphs on the 3D track map](docs/media/track-map-3d-jumps.png)
+
 **Lap list with dirty-lap flags** (💥 contact, ⏪ rewind) and A/B compare tags:
 
 ![Lap list with dirty-lap flags](docs/media/session-list.png)
@@ -83,6 +88,8 @@ the packet's elevation and is drag-to-rotate; the ✦ markers are detected conta
 conditions ribbons, plus the auto-named route:
 
 ![Session list with ribbons](docs/media/session-sidebar.png)
+
+**Settings** — units and map preferences, saved in your browser:
 
 ![Settings panel](docs/media/settings.png)
 
@@ -131,7 +138,8 @@ Then just drive. Telemetry is only sent while you're driving (not in menus). You
 ## Try it without the game
 
 No FH6 handy? A built-in simulator replays realistic telemetry so you can see the whole
-app work end to end:
+app work end to end. It needs a source checkout (`git clone`) and Python — it's a
+single stdlib script — and works against the exe or Docker alike:
 
 ```bash
 python tools/simulator.py                                   # ~3.5 laps, 1 event
@@ -154,9 +162,11 @@ can be blocked from sending to `127.0.0.1`:
    `192.168.1.20`), keeping port `9999`.
 3. Check the server actually sees packets at **http://localhost:8000/api/status**.
 
-The full flow — UWP loopback exemptions, the Docker IPv6-proxy port bug, and diagnosing
-an **event type that isn't being recorded** (with `LS_KEEP_DISCARDED` and
-`tools/inspect_session.py`) — lives in the **[Wiki](../../wiki)**.
+The full flow — UWP loopback exemptions, the Docker IPv6-proxy port bug, busy ports,
+wrong-size packets — lives in **[Troubleshooting](../../wiki/Troubleshooting)** on the
+Wiki. Diagnosing an **event type that isn't being recorded** (with `LS_KEEP_DISCARDED`
+and `tools/inspect_session.py`) has its own page:
+**[Capturing an Unrecognized Event](../../wiki/Capturing-an-Unrecognized-Event)**.
 
 ## Configuration
 
@@ -183,9 +193,11 @@ reference: [FH6 Data Out documentation](https://support.forza.net/hc/en-us/artic
 
 The interesting part is that FH6 gives *no* explicit event boundaries, no lap-invalidated
 flag, and no route names, and `DistanceTraveled` isn't even in meters on real circuits —
-so LapScope infers all of it from packet behavior. The deep dive (packet internals,
-event-detection model, the hard-won FH6 quirks) is in the **[Wiki](../../wiki)** and
-[AGENTS.md](AGENTS.md).
+so LapScope infers all of it from packet behavior. The deep dives live on the Wiki:
+**[FH6 Data Out Packet](../../wiki/FH6-Data-Out-Packet)** (the 324-byte layout and its
+quirks) and **[Event Detection](../../wiki/Event-Detection)** (how sessions, laps,
+finishes, and dirty-lap flags are inferred, with the real captures that proved each
+rule) — plus [AGENTS.md](AGENTS.md) for the dev-facing summary.
 
 ## Contributing
 

--- a/TODO.md
+++ b/TODO.md
@@ -119,10 +119,17 @@ the build. Playground Games ships new cars → new ordinals, so it goes stale.
 
 ## Docs
 
-- **Wiki** for advanced material (packet internals, event-detection deep dive,
-  capture-diagnosis workflow, the FH6 behavioral facts). README links to it.
-- Keep README basic: what it is, features, install, in-game setup, a little
-  troubleshooting.
+- ✅ **Wiki** shipped, authored in-repo: pages live in [docs/wiki/](docs/wiki/)
+  (Home, Troubleshooting, Capturing-an-Unrecognized-Event, FH6-Data-Out-Packet,
+  Event-Detection, plus `_Sidebar`/`_Footer`) and are mirrored to the GitHub
+  wiki by [.github/workflows/wiki.yml](.github/workflows/wiki.yml) on every
+  merge to main. `docs/wiki/` is the source of truth — never edit the wiki
+  directly. Convention recorded in AGENTS.md (documentation map) and
+  CONTRIBUTING.md; the unrecognized-event issue template deep-links the
+  capture page.
+- ✅ README kept basic and polished: troubleshooting/how-it-works now deep-link
+  the specific wiki pages, the jump-glyph screenshot and a Settings caption
+  were added, and the simulator section notes it needs a source checkout.
 
 ## Contact & lap-invalidation detection (accuracy)
 

--- a/docs/wiki/Capturing-an-Unrecognized-Event.md
+++ b/docs/wiki/Capturing-an-Unrecognized-Event.md
@@ -1,0 +1,116 @@
+# Capturing an unrecognized event
+
+FH6 never says "an event started" or "the race is over" — LapScope infers every
+session and lap boundary from packet behavior (see
+[Event Detection](Event-Detection)). When the game signals some event type in a
+way the inference doesn't recognize yet, the drive is either **discarded**,
+**mis-timed**, or **missing laps**. The only way LapScope learns a new event
+type is from a real capture — World Time Attack, dirt sprints, touge, and
+cross-country were each added exactly this way.
+
+**This is the most valuable kind of contribution.** Here's the workflow.
+
+## Why drives disappear in the first place
+
+Sessions that end without a single completed lap or run are discarded — that's
+the feature that keeps free-roam cruising and menu blips out of your session
+list. An event the inference doesn't recognize ends up in the same bucket: no
+lap was ever "completed", so the session is dropped at close (and stored
+leftovers are cleaned again at startup).
+
+## Step 1 — read the discard line
+
+Every discard logs a one-line signal summary. After driving the event, look in
+the console (exe) or `docker compose logs` (Docker):
+
+```
+Session 12 discarded (no completed laps, 4210 frames) | diag: dur=70s rt=0.0..68.2 maxLapNumber=0 maxCurrentLap=0.0 finish_seen=False gridded=True launch=True lastSpeed=51.3 dist=+1893
+```
+
+How to read the `diag:` fields:
+
+| Field | Meaning |
+|---|---|
+| `dur` | Session length in seconds. |
+| `rt` | `CurrentRaceTime` range — did the race clock run, and from where to where? |
+| `maxLapNumber` | Highest `LapNumber` seen. 0 = the game never counted a lap (normal for point-to-point and World Time Attack). |
+| `maxCurrentLap` | Highest `CurrentLap` clock seen. 0 = the per-lap clock never ran either. |
+| `finish_seen` | Whether any finish signal fired (lap-time change, odometer reset, clock freeze). |
+| `gridded` | Whether `RacePosition > 0` was ever seen — true means a real gridded event, never free roam. |
+| `launch` | Whether a launch anchor was armed (a `DistanceTraveled` reset followed by movement — the point-to-point/WTA start signature). |
+| `lastSpeed` | Speed on the final frame — high speed at cutoff usually means the stream was cut dead at a finish line. |
+| `dist` | How much `DistanceTraveled` grew over the session. |
+
+That one line often already narrows down what the inference missed.
+
+## Step 2 — keep the session: `LS_KEEP_DISCARDED=1`
+
+To preserve the session (raw frames included) instead of losing it, set
+`LS_KEEP_DISCARDED=1`, restart LapScope, and drive the event **once**:
+
+- **Docker** — put `LS_KEEP_DISCARDED=1` in a `.env` file next to
+  `docker-compose.yml` (compose reads it automatically), or set it inline:
+
+  ```powershell
+  $env:LS_KEEP_DISCARDED = "1"; docker compose up -d
+  ```
+
+- **Windows exe** — start it from a shell with the variable set:
+
+  ```powershell
+  cd <your LapScope folder>
+  $env:LS_KEEP_DISCARDED = "1"; .\LapScope.exe
+  ```
+
+  (Or `setx LS_KEEP_DISCARDED 1`, then double-click as usual — but remember to
+  `setx LS_KEEP_DISCARDED 0` afterwards, since that variant persists.)
+
+- **Running from source** — same variable, before `python run_desktop.py`.
+
+The kept session then shows up on the Analysis page (0 laps, but the driven
+line and an "incomplete" run are there), is exempt from the startup cleanup,
+and its raw frames are preserved for adding proper support. Set the variable
+back to `0` when you're done, or every free-roam cruise gets kept too.
+
+## Step 3 — dump the signals: `inspect_session.py`
+
+With a source checkout (plain stdlib — no container, no game, and the database
+is opened read-only):
+
+```powershell
+python tools/inspect_session.py --list                 # find the session id
+python tools/inspect_session.py 12
+```
+
+The default database path is `data/telemetry.db` (the Docker bind mount, run
+from the repo root). The Windows exe stores its database elsewhere — point the
+tool at it:
+
+```powershell
+python tools/inspect_session.py --list --db "$env:LOCALAPPDATA\LapScope\telemetry.db"
+```
+
+It prints one line per transition the segmentation cares about — `IsRaceOn`
+flips, race-clock resets and freezes, `DistanceTraveled` resets, lap-field
+activity, `RacePosition` changes, stream gaps, single-frame teleports — plus
+the first/last frame and any stored laps. This is the exact evidence needed to
+see what the event's signature looks like.
+
+## Step 4 — file the capture issue
+
+Open an
+[unrecognized event capture](https://github.com/darcane/LapScope/issues/new?template=unrecognized_event.yml)
+with:
+
+- what the event was and what you expected (e.g. "one run of ~92 s"),
+- the full `inspect_session.py` output,
+- your LapScope version,
+- whether you can share the session's `telemetry.db` — the raw frames are what
+  let a regression test be added, so support never breaks again.
+
+## Step 5 — after support lands: Reprocess
+
+Recordings are lossless raw packets, so once a fix ships, the **Reprocess**
+button on the session rebuilds its laps from the stored frames — nothing has
+to be re-driven. (Reprocess is refused with a 409 while any recording is in
+progress; wait ~15 s after you stop driving.)

--- a/docs/wiki/Event-Detection.md
+++ b/docs/wiki/Event-Detection.md
@@ -1,0 +1,188 @@
+# How LapScope detects events and laps
+
+FH6's telemetry never says what's happening. There is no "event started"
+message, no game-mode field, no lap-invalidated flag, no route names — and the
+game doesn't even count the last lap of a race (`LapNumber` stops incrementing
+at the finish). LapScope infers all of it from packet behavior.
+
+Every rule on this page exists because a **real capture** broke a naive
+version of the recorder, and each one is pinned by a headless regression test
+(the scenario matrix in
+[AGENTS.md](https://github.com/darcane/LapScope/blob/main/AGENTS.md) runs
+through [`tests/test_scenarios.py`](https://github.com/darcane/LapScope/blob/main/tests/test_scenarios.py),
+with matching [`tools/simulator.py`](https://github.com/darcane/LapScope/blob/main/tools/simulator.py)
+flags for full-stack checks). The implementation lives in
+[`app/recorder/laps.py`](https://github.com/darcane/LapScope/blob/main/app/recorder/laps.py).
+
+## Sessions
+
+- A **session** is a continuous stretch of `IsRaceOn = 1`. It ends after ~15
+  seconds of race-off or silence — which is why a finished drive appears on
+  the Analysis page about 15 s after packets stop.
+- `CurrentRaceTime` warping back to ~0 **splits** the session: that's an event
+  restart, or a free-roam time-attack launching.
+- Sessions that end without a single completed lap or run are **discarded** —
+  free-roam cruising and menu blips never clutter the list. If a real event
+  gets discarded, that's an unrecognized event type: see
+  [Capturing an Unrecognized Event](Capturing-an-Unrecognized-Event).
+
+## Race mode vs. free roam
+
+`IsRaceOn` is useless here — **it's 1 in free roam too** (it only separates
+driving from menus). An actual event is recognized by any of:
+
+- **A grid position:** `RacePosition > 0`, present from the very first
+  countdown frame of every gridded race.
+- **An odometer reset at launch:** World Time Attack and point-to-point events
+  reset `DistanceTraveled` to 0 when the run starts.
+- **Live lap fields:** `LapNumber` / `CurrentLap` actually counting.
+
+Free roam has none of these (verified on real captures). The result is the
+`race_mode` flag on every live frame — it drives the RACE MODE / FREE ROAM
+chip, gates the lap timer, and (unless you enable the free-roam map in
+Settings) the live track map.
+
+## Circuit laps, and the finish problem
+
+On circuits, `LapNumber` increments at the line and `LastLap` reports the
+game's own time — easy. The hard part is the **finish**, which never
+increments `LapNumber`. LapScope watches for five distinct finish signals,
+each verified on real data:
+
+1. **`LastLap` changes while `LapNumber` stands still** — the game posted a
+   final-lap time without counting the lap. The classic circuit-race finish.
+2. **`DistanceTraveled` hard-resets to ~0** — the real point-to-point finish
+   (verified on a dirt-sprint capture, 2026-07-03). The car crosses at speed,
+   `RacePosition` drops to 0, the stream gaps ~12 s for the results cinematic
+   (race clock counting through it), then the game hands control back
+   **parked at the line, brake held ~75 %, gear 1, odometer reset to 0**. On
+   circuits the odometer only ever accumulates, so a reset is unambiguous —
+   guarded against free-roam fast travel (which also zeroes it) by requiring
+   real distance covered **and** the car to stay put across the reset (a fast
+   travel teleports you away; a finish doesn't).
+3. **The race clock freezes ≥ 1.5 s while `IsRaceOn` stays 1** — a fallback
+   signal for finish cinematics that don't gap the stream.
+4. **The stream cuts dead at the line (circuits)** — real circuit races stop
+   Data Out the instant the race ends; the last packet lands within meters of
+   the finish, so none of the signals above ever arrive. At session end, an
+   open lap that covered ≥ 97 % of the session's typical lap length is
+   completed from the lap clock's last reading plus the remaining meters at
+   the last speed.
+5. **The same cutoff on a gridded point-to-point** — verified on a real touge
+   (2026-07-04): gridded 1v1, `CurrentLap` counting, crossing at 57 m/s with
+   `RacePosition` 1 and `IsRaceOn` still 1… and the stream just stops. No
+   reset, no freeze, no handback. Recovered at session end: gridded, launched
+   from an odometer reset, `LapNumber` never incremented, real distance
+   covered, still at speed → the run is timed and kept. **Cross-country shares
+   this exact signature** (verified 2026-07-05: gridded start P8→P3, cut dead
+   at the line at 67 m/s). These runs carry the **`cutoff` 🏁 flag**, because a
+   lap-one quit or a game crash looks identical — the time is inferred, not
+   confirmed by a finish signal.
+
+Timed runs are measured **launch-to-line** (the clock at the odometer-reset
+launch to the clock at the line, excluding the countdown) — matching the
+game's own convention: a circuit lap's `LastLap` is launch-to-line too,
+verified against a real session.
+
+Abandoned events with none of these signatures are discarded.
+
+## Event types and how they end
+
+Different FH6 event types end in different ways — this table is the union of
+the verified real captures and the simulator's regression scenarios:
+
+| Event type | Lap fields during the run | Finish signature |
+|---|---|---|
+| Circuit race | `LapNumber` counts, `LastLap` posts | `LastLap`-change, or stream cut dead at the line |
+| Rivals | endless laps, `LapNumber` counts | you leave — no finish needed |
+| Sprint (bare) | none run | odometer-reset handback, or cut dead → `cutoff` 🏁 |
+| Dirt sprint | `CurrentLap` runs, `LapNumber` stays 0 | odometer-reset handback after the results cinematic |
+| Touge | `CurrentLap` runs, `LapNumber` stays 0 | stream cut dead at the line → `cutoff` 🏁 |
+| Cross-country | `CurrentLap` runs, `LapNumber` stays 0 | stream cut dead at the line → `cutoff` 🏁 |
+| World Time Attack | **all four lap fields stay 0** | odometer hard-reset while the clock keeps counting |
+
+Point-to-point events may never start `CurrentLap` at all, so lap traces and
+the live delta fall back to race-time-elapsed-since-lap-open whenever the
+per-lap clock sits at zero.
+
+## World Time Attack: laps without lap fields
+
+WTA broadcasts **no lap information whatsoever** (verified on a real capture,
+2026-07-02: `LapNumber`, `CurrentLap`, `LastLap`, `BestLap` all 0 for the
+entire event, the race clock counting from event *load*, through a teleport to
+the track and a grid hold with `DistanceTraveled` pinned at 0). So laps are
+detected **geometrically**:
+
+- The **launch** is where `DistanceTraveled` starts growing — that position
+  becomes the anchor and the lap clock re-bases there.
+- A **lap completes** at the closest approach to the anchor after the car has
+  been ≥ 120 m away, is traveling within ~75° of the launch heading, and has
+  covered enough distance — a crossing normally finalizes when the car *exits*
+  the crossing circle.
+- The **run finish** is the `DistanceTraveled` hard-reset (~18 000 → 0) while
+  the clock keeps counting; the post-finish coast "lap" is deleted.
+- A stream that dies *inside* the crossing circle (cut at the final line) has
+  the pending closest approach finalized at session end, flagged `cutoff` 🏁.
+- A single-frame position jump > 250 m **disarms** geometric detection — you
+  never teleport mid-run, so it's a free-roam fast-travel giveaway.
+
+## Dirty laps: ⏪ rewind and 💥 contact
+
+The packet has no lap-invalidated field, so LapScope infers dirtiness:
+
+- **⏪ Rewind** — the lap clock drops below its high-water mark while distance
+  doesn't grow. (Comparing frame-to-frame instead of against the high-water
+  mark misses gradual scrubbing — that bug shipped once.) Rewound-over
+  stretches are trimmed from the charts and the map, so only the
+  finally-driven line remains.
+- **💥 Contact** — a ground-plane acceleration spike ≥ 45 m/s², beyond
+  anything tires can generate.
+
+**Jump landings are excused.** Horizon being Horizon, hard landings spike the
+accelerometer exactly like a wall. A spike while **airborne** — all four
+wheels at full droop (`NormalizedSuspensionTravel` < 0.15) with zero tire
+force (`TireCombinedSlip` < 0.05) for ≥ 0.12 s — or within 0.35 s of touchdown
+is classified as a **landing**, not contact: amber on the analysis map instead
+of red, excluded from the Contacts count, and the airborne stretch is drawn as
+an explicit takeoff ○ → flight → touchdown ▸ glyph on both maps. The
+thresholds were calibrated on a real cross-country session where 5 of its 12
+spikes were landings (touchdown compresses the suspension a frame or two
+*before* the spike, and suspension drifts up to ~0.11 mid-flight — hence the
+loose thresholds and the grace window), then verified to change nothing on
+circuit sessions.
+
+![Jump glyphs on the 3D analysis map](https://raw.githubusercontent.com/darcane/LapScope/main/docs/media/track-map-3d-jumps.png)
+
+**Known gap:** in Rivals, the faintest wall touch invalidates the lap in-game,
+but its lateral force is far below the contact threshold — and there is no
+packet field to cross-check against. Light scrapes are therefore missed (and a
+wall hit inside the 0.35 s post-landing grace is excused). Accepted trade-offs,
+tracked in [TODO.md](https://github.com/darcane/LapScope/blob/main/TODO.md).
+
+Flags reset when a lap re-anchors (a WTA launch, a mid-session lap-timer
+start), so pre-launch junk frames never dirty lap 1.
+
+## Routes
+
+The game never sends route names, so circuits are **fingerprinted**: same
+start position within 80 m + lap length within 5 % = same route. Name a route
+once and every past and future session on it picks the name up.
+
+## Reprocess: inference fixes apply retroactively
+
+Recordings are lossless raw packets, so the **Reprocess** button replays a
+session's stored frames through a fresh tracker — every detection improvement
+on this page can be applied to recordings made before it existed. (Refused
+with a 409 while any recording is in progress, so a long replay can't freeze
+live telemetry.)
+
+## Known accepted trade-offs
+
+Not bugs — revisit only with new signal data:
+
+- A fresh-boot free-roam session starting at `DistanceTraveled` 0 that loops
+  over its own start point *without* teleporting can produce one false
+  geometric lap.
+- A mid-run quit at speed is indistinguishable from a stream-cut
+  point-to-point finish; such runs carry the `cutoff` 🏁 flag rather than
+  being dropped.

--- a/docs/wiki/FH6-Data-Out-Packet.md
+++ b/docs/wiki/FH6-Data-Out-Packet.md
@@ -1,0 +1,82 @@
+# The FH6 "Data Out" packet
+
+Forza Horizon 6 broadcasts one fixed **324-byte little-endian UDP packet per
+rendered frame** while you're driving (nothing in menus, photo mode, or the
+pause screen). The layout is FH4/FH5's 324-byte "Dash" format; FH6's official
+documentation newly names the FH-specific block at offsets 232–243
+(`CarGroup`, `SmashableVelDiff`, `SmashableMass`). The final byte (offset 323)
+is undocumented padding, present since FH4.
+
+- Official reference: [FH6 Data Out documentation](https://support.forza.net/hc/en-us/articles/51744149102611-Forza-Horizon-6-Data-Out-Documentation)
+- LapScope's parser: [`app/telemetry/packet.py`](https://github.com/darcane/LapScope/blob/main/app/telemetry/packet.py)
+  — the struct is annotated field by field and verified by a round-trip
+  self-test (`python app/telemetry/packet.py`) and against the real game.
+
+## Layout at a glance
+
+| Offset block | Fields |
+|---|---|
+| 0–7 | `IsRaceOn` (i32), `TimestampMS` (u32) |
+| 8–19 | `EngineMaxRpm`, `EngineIdleRpm`, `CurrentEngineRpm` |
+| 20–43 | `AccelerationX/Y/Z`, `VelocityX/Y/Z` (both **car-local**, m/s²; X=right, Y=up, Z=forward) |
+| 44–67 | `AngularVelocityX/Y/Z`; `Yaw`, `Pitch`, `Roll` (**world-space**) |
+| 68–211 | Wheel arrays ×4: `NormalizedSuspensionTravel` (0 = full stretch, 1 = full compression), `TireSlipRatio`, `WheelRotationSpeed`, `WheelOnRumbleStrip`, `WheelInPuddleDepth`, `SurfaceRumble`, `TireSlipAngle`, `TireCombinedSlip` (>1 = past the grip limit), `SuspensionTravelMeters` |
+| 212–231 | `CarOrdinal`, `CarClass`, `CarPerformanceIndex`, `DrivetrainType`, `NumCylinders` |
+| 232–243 | `CarGroup`, `SmashableVelDiff`, `SmashableMass` (the FH-only block) |
+| 244–267 | `PositionX/Y/Z` (world meters); `Speed` (m/s), `Power` (W), `Torque` (Nm) |
+| 268–295 | `TireTemp` ×4 (**Fahrenheit**); `Boost` (psi), `Fuel`, `DistanceTraveled` |
+| 296–311 | `BestLap`, `LastLap`, `CurrentLap`, `CurrentRaceTime` (seconds) |
+| 312–322 | `LapNumber` (u16, 0-based), `RacePosition`, `Accel`, `Brake`, `Clutch`, `HandBrake` (0–255), `Gear` (0 = reverse), `Steer` (−127..127), `NormalizedDrivingLine`, `NormalizedAIBrakeDifference` |
+| 323 | undocumented padding |
+
+All wheel arrays are ordered **FL, FR, RL, RR**.
+
+## What's NOT in the packet
+
+Half of LapScope exists to work around what the game *doesn't* send:
+
+| Missing | LapScope's workaround |
+|---|---|
+| Route / track names | Circuits are fingerprinted from lap geometry (start position + lap length); you name a route once and every session on it picks the name up. |
+| Car name strings | `CarOrdinal` is looked up in a bundled community list (`app/car_ordinals.json`), with your own overrides on top. |
+| Weather | Wet conditions are inferred from `WheelInPuddleDepth` over the session; snow is a manual tag. |
+| Game mode (race / Rivals / free roam) | Inferred — see [Event Detection](Event-Detection). `IsRaceOn` does **not** mean "in an event" (below). |
+| Event boundaries / finishes | Inferred from lap fields, the odometer, the race clock, and the stream itself — see [Event Detection](Event-Detection). |
+| Lap-invalidated flag | Inferred dirty-lap flags: ⏪ rewind and 💥 contact — see [Event Detection](Event-Detection). |
+| Rival / opponent data | Only your car is broadcast, so LapScope compares you against your own best lap and the grip limit. |
+
+## Field quirks (verified on real captures)
+
+These are the facts that shaped the app — each one broke a naive assumption:
+
+- **`IsRaceOn` is 1 in free roam too.** It only separates *driving* from
+  *menus*. Detecting an actual event takes other signals: races grid you with
+  `RacePosition > 0` from the first countdown frame; World Time Attack and
+  point-to-point events reset `DistanceTraveled` to 0 at launch; free roam has
+  neither.
+- **`DistanceTraveled` is NOT meters on real circuits.** It advances by the
+  same fixed amount every lap of a given route — roughly 2.4–2.5× the true
+  driven length — making it a *track-position parameter*, not an odometer in
+  meters. That's perfect for aligning two laps by track position (how the A/B
+  comparison charts work) and for fingerprinting routes, but useless as a
+  length: the "Driven" figure on the analysis page is integrated from `Speed`
+  instead.
+- **`VelocityX/Y/Z` is car-local**, like `AccelerationX/Y/Z`: it reads
+  ~`(0, 0, speed)` whatever direction you're going in the world, so it can't
+  give a heading. **`Yaw` is world-space** — the car moves along
+  `(sin yaw, cos yaw)` in world X/Z (verified against position deltas).
+- **`TireTemp` is Fahrenheit**, whatever your in-game units.
+- `DrivetrainType`: 0 = FWD, 1 = RWD, 2 = AWD.
+- `CarClass` indexes into **D, C, B, A, S1, S2, R, X** — the **R class is new
+  in FH6** (901–998 PI; X is 999 only, verified on a real 998 car).
+- **The game binds its own socket on UDP ports 5200–5300** — pointing Data Out
+  there sends telemetry to the game itself. Never use that range.
+- **A title update can change the packet.** LapScope logs a warning with the
+  received size and a hex dump instead of crashing — see
+  [Troubleshooting](Troubleshooting#wrong-size-packets).
+
+## Recording format
+
+LapScope stores the raw 324-byte packets losslessly (~70 MB per driving hour),
+so every improvement to the inference can be replayed onto old recordings with
+the **Reprocess** button — nothing has to be re-driven.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,44 @@
+# LapScope Wiki
+
+LapScope is a self-hosted telemetry dashboard and lap analyzer for **Forza
+Horizon 6**. The [README](https://github.com/darcane/LapScope#readme) covers
+everything most people need — what it does, installing, the in-game Data Out
+settings, and quick troubleshooting. **This wiki is the deep end:** the material
+that would bloat the README but matters when something misbehaves or you want to
+know how the inference actually works.
+
+## Using LapScope
+
+- **[Troubleshooting](Troubleshooting)** — the full no-packets diagnosis flow:
+  UWP/Microsoft-Store loopback isolation, the LAN-IP fallback, the silent
+  Docker IPv6-proxy port bug, loopback exemptions, busy ports, and what
+  `/api/status` tells you.
+- **[Capturing an Unrecognized Event](Capturing-an-Unrecognized-Event)** — what
+  to do when a drive doesn't show up or is timed wrong: keep the discarded
+  session with `LS_KEEP_DISCARDED=1`, dump its signals with
+  `tools/inspect_session.py`, and file a capture issue so support can be added.
+  **This is the most valuable way to contribute.**
+
+## Internals
+
+- **[FH6 Data Out Packet](FH6-Data-Out-Packet)** — the 324-byte packet: layout,
+  what's *not* in it, and the field quirks that shaped the app
+  (`DistanceTraveled` isn't meters, `Velocity` is car-local, `IsRaceOn` is 1 in
+  free roam, …).
+- **[Event Detection](Event-Detection)** — how LapScope infers sessions, laps,
+  finishes, race mode, dirty-lap flags, and routes from a stream that never
+  announces any of them. Includes every finish signal and the real captures
+  that proved them.
+
+## In the repo
+
+- [README](https://github.com/darcane/LapScope#readme) — install, in-game
+  setup, features.
+- [CONTRIBUTING.md](https://github.com/darcane/LapScope/blob/main/CONTRIBUTING.md)
+  — workflow, branch rules, how to get changes in.
+- [ARCHITECTURE.md](https://github.com/darcane/LapScope/blob/main/ARCHITECTURE.md)
+  — code map: files, data flow, DB schema, API surface.
+- [AGENTS.md](https://github.com/darcane/LapScope/blob/main/AGENTS.md) — the
+  dev-facing knowledge base the recorder is built on.
+- [docs/BUILDING.md](https://github.com/darcane/LapScope/blob/main/docs/BUILDING.md)
+  — building the Windows exe from source and verifying a release download.

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,0 +1,121 @@
+# Troubleshooting
+
+The [README](https://github.com/darcane/LapScope#readme) has the short version.
+This page is the full diagnosis flow, in the order that finds the problem
+fastest.
+
+## First stop: `/api/status`
+
+Open **http://localhost:8000/api/status** (or `127.0.0.1:8000` for the exe). It
+answers most questions in one glance:
+
+| Field | Meaning |
+|---|---|
+| `udp_error` | Non-null = LapScope **could not bind its UDP port** (another program has it). Nothing will arrive until that's fixed — see [Busy ports](#busy-ports) below. |
+| `packets_total` | Total telemetry packets received since start. `0` while driving = the game's packets aren't reaching LapScope — see [No packets arriving](#no-packets-arriving). |
+| `bad_packets` / `last_packet_size` | Packets of the wrong size. Non-zero = something else is sending to the port, or a game update changed the packet — see [Wrong-size packets](#wrong-size-packets). |
+| `last_packet_age` | Seconds since the last packet. Remember: FH6 only sends **while you're driving**, not in menus or the pause screen. |
+| `session_active` / `session_id` / `session_best` | What the recorder is doing right now. |
+| `version` | The running build (`0.0.0` = unversioned source run). |
+
+**Where the logs are:** the console window for the Windows exe,
+`docker compose logs -f` for Docker. Every recorder decision (session opened,
+lap completed, session discarded + why) is logged there.
+
+## No packets arriving
+
+`packets_total` stays 0 while you drive. Most common with **Microsoft Store /
+Xbox-app (UWP) builds** of the game, which can be blocked from sending UDP to
+`127.0.0.1`. Work through these in order:
+
+### 1. Try plain loopback first
+
+In FH6 under **Settings → HUD and Gameplay**: Data Out `ON`, IP `127.0.0.1`,
+port `9999`. This is officially supported and works for most installs. Telemetry
+only flows while driving, so be on the road when you check.
+
+> ⚠️ Never use ports **5200–5300** — the game binds its own socket in that
+> range, and the packets will go to the game instead of LapScope.
+
+### 2. Use your PC's LAN IP instead
+
+Find it with `ipconfig` (e.g. `192.168.1.20`) and put **that** as the Data Out
+IP, keeping port `9999`. This bypasses UWP loopback isolation: LapScope listens
+on all interfaces (both the exe and the Docker container), so packets addressed
+to your LAN IP land in the same place. If Windows Firewall prompts when LapScope
+first starts, allow it — a blocked inbound rule looks exactly like "no packets".
+
+### 3. Check nothing stole the UDP port (Docker's silent failure mode)
+
+Another app can grab UDP 9999 — and with Docker specifically it can happen
+*silently*: if the port is taken while the container is being recreated,
+Docker's proxy binds **only IPv6**, everything looks up and running, and
+`/api/status` shows 0 packets forever. Check who owns the port:
+
+```powershell
+Get-NetUDPEndpoint -LocalPort 9999 | Format-Table LocalAddress, OwningProcess
+Get-Process -Id <OwningProcess>
+```
+
+If a process other than `com.docker.backend` (Docker) or `LapScope`/`python`
+(exe/source) owns `0.0.0.0:9999`, close it — or move LapScope to a free port
+with `TELEMETRY_UDP_PORT` — then restart:
+`docker compose down && docker compose up -d`.
+
+The native exe doesn't have this failure mode: if it can't bind the port it
+says so, in the console and in `/api/status` → `udp_error`.
+
+### 4. Last resort: a UWP loopback exemption
+
+Tell Windows to let the Store version of Forza send to loopback (one-time,
+admin PowerShell):
+
+```powershell
+Get-AppxPackage *Forza* | Select-Object PackageFamilyName
+CheckNetIsolation.exe LoopbackExempt -a -n=<PackageFamilyName>
+```
+
+Then set the Data Out IP back to `127.0.0.1`.
+
+## Busy ports
+
+- **UDP 9999 already in use** — LapScope starts anyway (the dashboard and past
+  sessions still work) but shows the problem in the console and in
+  `/api/status` → `udp_error`. Close the other program (often a second LapScope
+  window, or another telemetry tool), or set `TELEMETRY_UDP_PORT` to a free
+  port, then restart — and remember to change the port in the game too.
+- **HTTP 8000 already in use** (exe) — the exe checks before starting and
+  explains instead of crash-closing the console. Usually it's an
+  already-running LapScope: open http://127.0.0.1:8000 — if the dashboard
+  loads, use that window. To find another culprit:
+  `Get-NetTCPConnection -LocalPort 8000 | Format-Table OwningProcess`.
+
+## Wrong-size packets
+
+LapScope expects exactly **324 bytes** per packet. On the first wrong-size
+packet it logs a warning with the received size and a hex dump, and counts the
+rest in `bad_packets`:
+
+- **Wrong sender**: something other than FH6 is transmitting to the port —
+  a different Forza title whose packet is another size (only FH4/FH5's "Dash"
+  format matches FH6's 324 bytes), or another telemetry tool's forwarder.
+- **A game update changed the layout**: if this starts right after an FH6 title
+  update and the size is new, the packet probably grew. Check for a LapScope
+  update, and if there is none yet, please
+  [open a bug report](https://github.com/darcane/LapScope/issues/new?template=bug_report.yml)
+  with the logged size — that warning line is exactly what's needed to adapt
+  the parser. Details of the current layout:
+  [FH6 Data Out Packet](FH6-Data-Out-Packet).
+
+## A session or lap is missing / timed wrong
+
+That's not a connectivity problem — it's the event-detection inference not
+recognizing something. See
+[Capturing an Unrecognized Event](Capturing-an-Unrecognized-Event) for the
+capture workflow, and [Event Detection](Event-Detection) for how the inference
+works.
+
+## Still stuck?
+
+[Open a bug report](https://github.com/darcane/LapScope/issues/new?template=bug_report.yml)
+with your `/api/status` output and the relevant log lines.

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,1 @@
+These pages are mirrored from [`docs/wiki/`](https://github.com/darcane/LapScope/tree/main/docs/wiki) in the main repo — please don't edit the wiki directly (changes would be overwritten by the next sync); open a PR against `docs/wiki/` instead. · LapScope is an unofficial, fan-made tool and is not affiliated with or endorsed by Playground Games, Turn 10, or Microsoft.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,17 @@
+**[Home](Home)**
+
+**Using LapScope**
+
+- [Troubleshooting](Troubleshooting)
+- [Capturing an Unrecognized Event](Capturing-an-Unrecognized-Event)
+
+**Internals**
+
+- [FH6 Data Out Packet](FH6-Data-Out-Packet)
+- [Event Detection](Event-Detection)
+
+**In the repo**
+
+- [README](https://github.com/darcane/LapScope#readme)
+- [Contributing](https://github.com/darcane/LapScope/blob/main/CONTRIBUTING.md)
+- [Building from source](https://github.com/darcane/LapScope/blob/main/docs/BUILDING.md)


### PR DESCRIPTION
## Summary

Resolves the TODO **Docs** item: the GitHub wiki was an empty stub while the README (and the unrecognized-event issue template) already pointed at it — the deep troubleshooting material (UWP loopback exemptions, the Docker IPv6-proxy port bug) had been cut in the public README rewrite (#3) and existed nowhere. This PR:

- **Authors the wiki in-repo** under `docs/wiki/`: `Home`, `Troubleshooting`, `Capturing-an-Unrecognized-Event`, `FH6-Data-Out-Packet`, `Event-Detection`, plus `_Sidebar`/`_Footer`. Content mined from AGENTS.md, the pre-rewrite README, and the recorder sources — no new facts invented (packet offsets verified against `packet.py`; the `diag:` line matches the current format string).
- **Publishes it automatically**: new `.github/workflows/wiki.yml` mirrors `docs/wiki/` to the GitHub wiki on every merge to `main` that touches it (plus `workflow_dispatch`). `docs/wiki/` is the **source of truth — never edit the wiki on GitHub**; the sync overwrites it.
- **Polishes the README**: troubleshooting / how-it-works now deep-link the specific wiki pages; adds the jump-glyph screenshot and a Settings caption; notes the simulator needs a source checkout.
- **Records the convention** so it stays current: AGENTS.md documentation map (now five surfaces, with the "update the matching docs/wiki page in the same PR" rule), CONTRIBUTING.md, ARCHITECTURE.md; the unrecognized-event issue template deep-links the capture walkthrough; TODO Docs section marked ✅.

**Reviewer notes**
- Merging this PR triggers the first wiki publish. The workflow pushes with the default `GITHUB_TOKEN` (`contents: write`); if that ever 403s on the wiki repo, the fallback (PAT as `WIKI_TOKEN`) is documented in the workflow header.
- Wiki pages link each other wiki-style (`[text](Page-Name)`, no `.md`) — those links resolve on the published wiki, not when browsing `docs/wiki/` in the repo. Repo files/images are linked by absolute URL.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Event-detection change (recorder / `laps.py`)
- [x] Docs only
- [ ] Refactor / chore

## How was it tested?

- Mirror logic dry-run against a real clone of `LapScope.wiki.git` (rsync-equivalent + commit, no push): stub Home replaced, 7 pages staged cleanly.
- Link/image audit script: every inter-page link targets an existing page; every `raw.githubusercontent`/`blob/main` URL and README image path maps to a real file.
- `ruff check .`, `python app/telemetry/packet.py`, `pytest -q` (32 passed) — no code touched.
- `wiki.yml` + edited issue template sanity-parsed as YAML.

## Checklist

- [x] Branched off `main` (named `docs/…` — docs-only change, matching the `docs:` commit prefix convention).
- [x] `ruff check .` passes.
- [x] `python app/telemetry/packet.py` (packet self-test) passes.
- [x] `pytest -q` passes.
- [x] Docs updated where relevant (AGENTS.md, ARCHITECTURE.md, CONTRIBUTING.md, README.md, TODO.md — this PR *is* the docs change).
- [ ] For a new detection scenario: n/a.
- [x] Cross-file invariants kept in sync (adds a new one: `docs/wiki/` pages ↔ the knowledge in AGENTS.md — recorded in the documentation map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)