### PR TITLE
fix(ci): append auto-generated changelog to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
           (Get-FileHash $zip -Algorithm SHA256).Hash + "  " + $zip | Out-File -Encoding ascii checksums.txt
           Get-Content checksums.txt
 
+      # Static header only (install + verify instructions). The per-release
+      # changelog is appended automatically by generate_release_notes below.
       - name: Compose release notes
         shell: pwsh
         run: |
@@ -124,3 +126,7 @@ jobs:
             LapScope-${{ github.ref_name }}-win64.zip
             checksums.txt
           body_path: release_notes.md
+          # Appends GitHub's auto-generated "What's Changed" (merged PRs since
+          # the previous tag + full-changelog link) below the static body above,
+          # so each release actually describes what changed in it.
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

The release workflow's "Compose release notes" step builds a fully static body (install + SmartScreen/checksum instructions) — it never looks at commits, so every release published identical notes with no record of what changed (see v0.3 vs v0.4 before the manual edit).

This enables `generate_release_notes: true` on `softprops/action-gh-release`: GitHub appends its auto-generated **What's Changed** section (merged PRs since the previous tag + the full-changelog compare link) below the static header. Since everything merges via PRs with conventional titles, each release now gets a real changelog with zero maintenance. Also adds a comment on the compose step clarifying it produces the static header only.

## Type of change

- [x] Bug fix

## How was it tested?

- Workflow YAML sanity-parsed; `generate_release_notes` is passed through to the GitHub create-release API, which pre-pends the provided `body` to the generated notes (documented behavior of both the action and the API).
- No app code touched — CI-only change; the effect is observable on the next `v*` tag push.

## Checklist

- [x] Branched off `main` as `fix/…`.
- [x] `ruff check .` passes (no Python touched).
- [x] `python app/telemetry/packet.py` (packet self-test) passes (no code touched).
- [x] `pytest -q` passes (no code touched).
- [x] Docs updated where relevant (n/a — workflow comment updated in place).
- [ ] For a new detection scenario: n/a.
- [x] Cross-file invariants kept in sync (none affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)