### PR TITLE
feat(recorder): auto-suggest track type from telemetry + route-wide r…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,16 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 - `DrivetrainType`: 0=FWD 1=RWD 2=AWD. `CarClass`: index into D,C,B,A,S1,S2,R,X
   (R is new in FH6: 901–998 PI; X is 999 only — verified on a real 998 car).
 - Wheel arrays are ordered FL, FR, RL, RR. `TireTemp` is Fahrenheit.
+- **`TireCombinedSlip` does NOT discriminate surface** (swept across all
+  stored captures, 2026-07-12): it tracks driver aggression — hard tarmac
+  laps sustain *more* slip than clean dirt runs. Surface detection uses
+  suspension roughness + jump rate instead.
+- **`NormalizedDrivingLine` saturates at ±127 far off the course**; during
+  events it sits mid-range 73–97 % of frames on every surface (dirt courses
+  have a driving line too). Used as the on-course gate for surface evidence.
+  `NormalizedAIBrakeDifference` is ~0 on most frames — no useful signal.
+  Free-roam behavior of both is **unverified** (free-roam sessions are
+  discarded, so no stored captures to check against).
 - The game binds its own socket on ports **5200–5300** — never use them.
 - Xbox-app (UWP) builds may block loopback; fallbacks documented in README.
 
@@ -243,9 +253,30 @@ All the rules exist because some real behavior broke a naive version:
   (`Store._next_session_id`), never SQLite's rowid: discards delete the max
   rowid, which plain `INTEGER PRIMARY KEY` would reuse — and the live map
   resets on session-id *change*, so a reused id left stale points on screen.
-- Track types are a manual tag; the allowed set lives in **three places that
-  must stay in sync**: `TRACK_TYPES` (api/routes.py), `TRACK_META` (common.js),
-  and the `#track-select` options (analysis.html).
+- **Track types are auto-suggested at session close** (issue #28), written
+  with COALESCE so a user tag always wins; the dropdown stays the override.
+  Precedence: (1) another session on the same route carries a tag → inherit
+  it (routes don't change surface; this propagates manual corrections);
+  (2) geometric laps → `wtc` (loop closure to the launch anchor is
+  near-certain WTA); (3) surface: ≥10 % rough suspension frames
+  (travel rate > 2.8/s) at ≥0.7 jumps/min → `dirt`, ≥3.5 jumps/min →
+  `cross`, ≤3 % rough and <0.7 jumps/min → `road`; in-between or thin
+  evidence → no tag. Frames with `|NormalizedDrivingLine| = 127` (far off
+  course) and flights taken off-course contribute **no** surface evidence —
+  off-roading a tarmac event can't fake a dirt tag. Near-zero cornering
+  (drag strips) → no tag. street/touge read as tarmac → suggested `road`
+  (accepted; one manual correction sticks via route inheritance).
+  Thresholds calibrated on the stored real captures (2026-07-12 sweep,
+  dump/hand-label/DB-sweep like the landing classifier): 9/9 labeled
+  sessions matched, 0 hard mismatches. Reprocess back-fills old sessions
+  (`_ReplayStore.end_session` applies auto-tags only). Manually changing a
+  session's type offers to retag the whole route (`PATCH /routes/{id}`
+  `track_type`).
+- The allowed track-type set lives in **three places that must stay in
+  sync**: `TRACK_TYPES` (api/routes.py), `TRACK_META` (common.js), and the
+  `#track-select` options (analysis.html) — plus everything
+  `suggest_track_type` (laps.py) can return must be a member of
+  `TRACK_TYPES` (locked by a test).
 
 When changing `_lap_logic`, walk every branch against: circuit race with finish,
 Rivals (endless laps), free-roam cruise, free-roam time-attack, sprint, dirt
@@ -296,5 +327,10 @@ a row here, a test, and usually a simulator flag.
 | World Time Attack | `--wta 3` | launch + 3 geometric laps + distance-reset finish, no post-finish phantom lap |
 | WTA, stream cut at the line | `--wta 3 --cut` | 3 geometric laps, last flagged `cutoff` (pending crossing finalized at session end), no phantom lap |
 | Jumps in 3D | `--sprint 75 --jumps` (or any + `--jumps`) | 3D map scale sane, spikes capped, run NOT flagged `contact` (landings excused) |
+| Track type: circuit/sprint | `--race 3` / `--sprint 75` | session auto-tagged `road` (smooth suspension, no jumps) |
+| Track type: dirt | `--dirt 60` | auto-tagged `dirt` (washboard suspension, low jump rate) |
+| Track type: cross | `--dirt 60 --jumps` | auto-tagged `cross` (dirt surface + a crest every few hundred meters) |
+| Track type: WTA | `--wta 3` | auto-tagged `wtc` (geometric laps) |
+| Track type: route inheritance | two events, same route | a tag set on the route's earlier session wins over telemetry for later ones |
 | Landing vs contact | `--duration 180 --dirty --jumps` | lap 2 `contact` (wall hit), all other laps clean despite hard jump landings; `/laps/{id}/data` tags landing bursts `landing: true` (amber on the map) |
 | Race-mode gating | `--freeroam 35 --race 3` | chip FREE ROAM then RACE MODE; timer dashed in free roam; live map draws the race only |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 | [app/telemetry/packet.py](app/telemetry/packet.py) | 324-byte Data Out struct: `parse()`, `pack()` (simulator/tests), `empty_fields()`, `FIELDS` name/count table. Self-test via `python app/telemetry/packet.py`. |
 | [app/telemetry/listener.py](app/telemetry/listener.py) | `asyncio.DatagramProtocol`: counts packets, warns once on wrong size (hex dump), parses, feeds tracker, publishes frame+extras to hub. Recorder exceptions never kill the stream. |
 | [app/telemetry/hub.py](app/telemetry/hub.py) | Fan-out to WebSocket subscriber queues (drop-oldest on slow clients) + stream stats used by `/api/status`. |
-| [app/recorder/laps.py](app/recorder/laps.py) | **The heart.** `SessionTracker`: session boundaries, lap segmentation, finish detection, geometric (WTA) laps, dirty-lap flags, wet detection, route fingerprint triggers, live delta, `race_mode`. All tunable thresholds are module constants at the top. |
+| [app/recorder/laps.py](app/recorder/laps.py) | **The heart.** `SessionTracker`: session boundaries, lap segmentation, finish detection, geometric (WTA) laps, dirty-lap flags, wet detection, route fingerprint triggers, live delta, `race_mode`, and the track-type auto-suggestion (`suggest_track_type` + per-frame surface accumulators; written at session close with COALESCE so user tags win). All tunable thresholds are module constants at the top. |
 | [app/recorder/store.py](app/recorder/store.py) | SQLite persistence: schema, `MIGRATIONS`, session/lap/route/car-name CRUD, monotonic session-id counter, `reader()` for threadpool access. |
 | [app/recorder/reprocess.py](app/recorder/reprocess.py) | Replays a session's stored raw frames through a fresh `SessionTracker` via `_ReplayStore` (laps/routes written for real; session row and frames untouched; discard suppressed). |
 | [app/api/routes.py](app/api/routes.py) | REST API (table below) + constants: `CAR_CLASSES`, `CONDITIONS`, `TRACK_TYPES`, `DRIVETRAINS`, `CHANNELS` (channel-name → frame extractor for lap data). |
@@ -70,7 +70,7 @@ each runs on every startup inside try/except (existing-column errors swallowed).
 | `DELETE /sessions/{id}` | Cascades frames+laps. 409 while recording. |
 | `GET /sessions/{id}/laps` | Session + laps with `is_best` / `gap_to_best`. |
 | `GET /laps/{id}/data?channels=&max_points=` | Distance-indexed channel arrays; drops rewound-over samples; decimates to `max_points`. Channel names = `CHANNELS` keys in routes.py. `lap_time` falls back to time-since-lap-start when the packet lap clock never ran (WTA / bare sprints keep `CurrentLap` at 0), so the A/B Δ-time chart works for those events. Also returns `collisions` (contact-spike peaks, `landing: true/false`) and `jumps` (airborne segments: takeoff → touchdown world coords + `dist0/dist1`, `air_s`, `hard` + peak `g` when the landing spiked) — both computed on the full-resolution trace, never decimated away. |
-| `PATCH /routes/{id}`, `GET/PATCH /cars/{ordinal}` | Rename route / car override (car `name: ""` reverts the override to the bundled/downloaded name). `GET` also returns `known` (ordinal resolvable without the `Car #<id>` fallback). |
+| `PATCH /routes/{id}`, `GET/PATCH /cars/{ordinal}` | Route: `name` renames, `track_type` retags **every session on the route** at once (the analysis page offers this when a session's type is changed; `""` clears them all). Car override (`name: ""` reverts to the bundled/downloaded name). `GET` also returns `known` (ordinal resolvable without the `Car #<id>` fallback). |
 | `GET /cars`, `POST /cars/refresh` | Car-list metadata (`total`, `fetched_at`) / re-download the community list (see app/cars.py row above; 502 with a readable `detail` on failure — the current list stays). Registered before `/cars/{ordinal}` so `refresh` isn't parsed as an ordinal. |
 
 ## WebSocket `/ws/live` frame
@@ -186,7 +186,9 @@ assert them here.
 ## Cross-file invariants (change one → change all)
 
 - Track-type set: `TRACK_TYPES` (api/routes.py) = `TRACK_META` (common.js)
-  = `#track-select` options (analysis.html).
+  = `#track-select` options (analysis.html); everything `suggest_track_type`
+  (laps.py) can return must be a member of `TRACK_TYPES` (locked by a test
+  in test_api.py).
 - Settings map options: the `defaultMapMode` / `defaultColor` values offered by
   the panel (`settings.js`) must match the `#map-mode` (`2d`/`3d`) and
   `#color-mode` (`speed`/`slip`) options in analysis.html; `analysis.js` seeds

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ in Rivals.
   Free-roam cruising is discarded automatically, so the list stays clean.
 - **Session metadata** — Forza-colored class/PI ribbons (incl. the new **R class**),
   drivetrain badges, car names (bundled community ordinal list + your overrides),
-  auto-detected wet conditions, and a track-type tag.
+  auto-detected wet conditions, and a track-type tag that fills itself in
+  (road/dirt/cross-country/WTC read from the telemetry, your override always wins —
+  and can be applied to a whole route in one click).
 - **Routes** — the game never sends route names, so circuits are fingerprinted from lap
   geometry. Name a route once and every past and future session on it picks it up.
 - **Settings** — a ⚙ **Settings** panel (top-right on both pages) to switch units —

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -158,12 +158,27 @@ class NameBody(BaseModel):
     name: str
 
 
+class RoutePatch(BaseModel):
+    name: str | None = None
+    track_type: str | None = None
+
+
 @router.patch("/routes/{route_id}")
-def rename_route(route_id: int, body: NameBody, request: Request):
-    if not body.name.strip():
-        raise HTTPException(400, "name must not be empty")
-    if not request.app.state.store.rename_route(route_id, body.name.strip()[:80]):
+def patch_route(route_id: int, body: RoutePatch, request: Request):
+    """Rename a route and/or retag every session recorded on it in one go
+    (the analysis page offers the retag when a session's type is changed -
+    a route's surface doesn't change, so the tag belongs to all of them)."""
+    store = request.app.state.store
+    if not store.route_exists(route_id):
         raise HTTPException(404, "route not found")
+    if body.name is not None:
+        if not body.name.strip():
+            raise HTTPException(400, "name must not be empty")
+        store.rename_route(route_id, body.name.strip()[:80])
+    if body.track_type is not None:  # "" clears the tag on every session
+        if body.track_type and body.track_type not in TRACK_TYPES:
+            raise HTTPException(400, f"track_type must be one of {sorted(TRACK_TYPES)}")
+        store.set_route_sessions_track_type(route_id, body.track_type or None)
     return {"ok": True}
 
 

--- a/app/recorder/laps.py
+++ b/app/recorder/laps.py
@@ -81,6 +81,18 @@ LS_KEEP_DISCARDED=1 keeps such sessions (raw frames included) instead of
 deleting them - drive the unrecognized event once with the flag on and the
 data needed to add support for it is preserved.
 
+Sessions that complete laps also get a track-type suggestion at close
+(road/dirt/cross/wtc), written with COALESCE so a user tag always wins: a
+route that already carries a type passes it on (routes don't change
+surface, and it propagates manual corrections); otherwise geometric (WTA)
+laps mean wtc, and the surface is read from suspension roughness + jump
+rate - NOT tire slip, which tracks driver aggression, not surface (hard
+tarmac laps out-slip clean dirt runs on real captures). Frames far off the
+course line (|NormalizedDrivingLine| saturated at 127) contribute no
+surface evidence, so deliberately off-roading a tarmac event can't fake a
+dirt tag. street/touge/drag are indistinguishable from telemetry and never
+suggested; when the evidence is thin or ambiguous, no tag at all.
+
 The packet carries no "lap invalidated" flag, so lap dirtiness is inferred:
 - rewind: the lap clock ran backwards mid-lap (reversing on track never
   does that - time only runs forward), corroborated by DistanceTraveled
@@ -142,9 +154,54 @@ WTA_TELEPORT_JUMP = 250.0     # single-frame position jump = fast travel (free r
 POINT_FINISH_DIST = 200.0     # DistanceTraveled must land this close to 0 for a
                               # reset to count as a point-to-point finish
 
+# Track-type auto-suggestion: thresholds calibrated on the stored real
+# captures (2026-07-12 sweep, same dump/hand-label method as the landing
+# classifier). Labeled dirt sessions showed 10-16 % rough frames at 1.0-2.5
+# jumps/min; tarmac (road/street/touge) 0-1.3 % at 0-0.5; cross-country
+# 4.9-13 jumps/min; drag near-zero cornering. TireCombinedSlip does NOT
+# separate surfaces - it tracks driver aggression, not the ground.
+TRACK_DRIVE_SPEED_MIN = 8.0    # m/s: below this the frame isn't "driving"
+TRACK_OFF_LINE = 127           # |NormalizedDrivingLine| saturates at 127 far
+                               # off the course - such frames are no surface
+                               # evidence (off-roading must not fake "dirt")
+TRACK_ROUGH_DT_MAX = 0.25      # s: consecutive-frame gap limit for the rate
+TRACK_ROUGH_RATE = 2.8         # susp travel fraction/s that reads "rough"
+TRACK_DIRT_ROUGH_FRAC = 0.10   # rough-frame share >= this, and ...
+TRACK_DIRT_JPM = 0.7           # ... jumps per driving minute >= this = dirt
+TRACK_CROSS_JPM = 3.5          # jumps/min >= this = cross-country
+TRACK_ROAD_ROUGH_FRAC = 0.03   # rough share <= this (and few jumps) = tarmac
+TRACK_CORNER_STEER = 30        # |Steer| beyond this counts as cornering
+TRACK_CORNER_FRAC_MIN = 0.10   # under this share of cornering frames = a
+                               # drag-like straight strip: suggest nothing
+TRACK_MIN_DRIVE_S = 30.0       # too little driving to judge a surface
+
 # keep sessions that would otherwise be discarded (no completed laps) - for
 # capturing event types the segmentation doesn't recognize yet
 KEEP_DISCARDED = os.environ.get("LS_KEEP_DISCARDED", "0").lower() not in ("", "0", "false")
+
+
+def suggest_track_type(*, geometric_laps: int, drive_s: float, drive_n: int,
+                       corner_n: int, rough_n: int, rough_hi: int,
+                       jumps: int) -> str | None:
+    """Track type suggested by a session's accumulated evidence, or None when
+    not confident. Geometric (WTA) laps trump surface: crossing back to the
+    launch anchor is near-certain wtc, whatever the ground. Every returned
+    value must be a member of TRACK_TYPES (api/routes.py) - locked by test."""
+    if geometric_laps > 0:
+        return "wtc"
+    if drive_s < TRACK_MIN_DRIVE_S or not drive_n or not rough_n:
+        return None
+    if corner_n / drive_n < TRACK_CORNER_FRAC_MIN:
+        return None  # a straight strip: drag, most likely - don't guess
+    jpm = jumps / (drive_s / 60.0)
+    rough = rough_hi / rough_n
+    if jpm >= TRACK_CROSS_JPM:
+        return "cross"
+    if rough >= TRACK_DIRT_ROUGH_FRAC and jpm >= TRACK_DIRT_JPM:
+        return "dirt"
+    if rough <= TRACK_ROAD_ROUGH_FRAC and jpm < TRACK_DIRT_JPM:
+        return "road"
+    return None  # the gap zone between surfaces: leave untagged
 
 
 class SessionTracker:
@@ -200,6 +257,18 @@ class SessionTracker:
         self._landing_grace_until = 0.0        # spikes before this t = landing
         self._over_impact = False              # inside a spike burst (log once)
         self._route_assigned = False
+        self._route_id: int | None = None
+        self._geometric_laps = 0
+        # track-type evidence (driving frames on the course proper)
+        self._prev_on_line = True
+        self._air_on_line = True   # was the car on-course when it took off?
+        self._trk_prev: tuple[float, list[float]] | None = None  # (t, susp)
+        self._trk_drive_s = 0.0
+        self._trk_drive_n = 0
+        self._trk_corner_n = 0
+        self._trk_rough_n = 0
+        self._trk_rough_hi = 0
+        self._trk_jumps = 0
         self._session_start_t = 0.0
         self._diag_first_dist: float | None = None
         self._diag_max_ln = 0
@@ -255,13 +324,36 @@ class SessionTracker:
             self._puddle_frames += 1
         airborne = (all(s < AIRBORNE_SUSP_MAX for s in frame["norm_susp_travel"])
                     and all(s < AIRBORNE_SLIP_MAX for s in frame["tire_combined_slip"]))
+        on_line = abs(frame["normalized_driving_line"]) < TRACK_OFF_LINE
         if airborne:
             if self._air_since is None:
                 self._air_since = t
+                self._air_on_line = self._prev_on_line
         else:
             if self._air_since is not None and t - self._air_since >= AIRBORNE_MIN_S:
                 self._landing_grace_until = t + LANDING_GRACE_S
+                if self._air_on_line:  # flights taken off-course don't count
+                    self._trk_jumps += 1
             self._air_since = None
+        self._prev_on_line = on_line
+        # surface evidence for the track-type suggestion: driving frames on
+        # the course proper (see the module docstring for the off-line gate)
+        if frame["speed"] >= TRACK_DRIVE_SPEED_MIN and not airborne and on_line:
+            self._trk_drive_n += 1
+            if abs(frame["steer"]) > TRACK_CORNER_STEER:
+                self._trk_corner_n += 1
+            if self._trk_prev is not None:
+                dt = t - self._trk_prev[0]
+                if 0.0 < dt < TRACK_ROUGH_DT_MAX:
+                    self._trk_drive_s += dt
+                    rate = sum(abs(a - b) for a, b in zip(
+                        frame["norm_susp_travel"], self._trk_prev[1])) / 4.0 / dt
+                    self._trk_rough_n += 1
+                    if rate > TRACK_ROUGH_RATE:
+                        self._trk_rough_hi += 1
+            self._trk_prev = (t, frame["norm_susp_travel"])
+        else:
+            self._trk_prev = None
         flying = self._air_since is not None and t - self._air_since >= AIRBORNE_MIN_S
         g = math.hypot(frame["accel_x"], frame["accel_z"])
         if g >= IMPACT_ACCEL:
@@ -355,6 +447,17 @@ class SessionTracker:
         self._landing_grace_until = 0.0
         self._over_impact = False
         self._route_assigned = False
+        self._route_id = None
+        self._geometric_laps = 0
+        self._prev_on_line = True
+        self._air_on_line = True
+        self._trk_prev = None
+        self._trk_drive_s = 0.0
+        self._trk_drive_n = 0
+        self._trk_corner_n = 0
+        self._trk_rough_n = 0
+        self._trk_rough_hi = 0
+        self._trk_jumps = 0
         self._session_start_t = t
         self._diag_first_dist = frame["distance_traveled"]
         self._diag_max_ln = frame["lap_number"]
@@ -395,6 +498,7 @@ class SessionTracker:
                     rid = self.store.match_or_create_route(
                         self._lap_start_pos[0], self._lap_start_pos[1], length)
                     self.store.set_session_route(self.session_id, rid)
+                    self._route_id = rid
             self.store.complete_lap(self._lap_id, end_t, lap_time, self._flags())
             if lap_time is not None:
                 self._completed_laps += 1
@@ -427,10 +531,14 @@ class SessionTracker:
         else:
             wet = (self._frame_count > 0
                    and self._puddle_frames / self._frame_count > WET_FRAME_FRACTION)
+            track = self._suggest_track()
             self.store.end_session(self.session_id, end_t, self._frame_count,
-                                   conditions="wet" if wet else None)
-            log.info("Session %d ended (%d frames, %d laps%s)", self.session_id,
-                     self._frame_count, self._completed_laps, ", wet" if wet else "")
+                                   conditions="wet" if wet else None,
+                                   track_type=track)
+            log.info("Session %d ended (%d frames, %d laps%s%s)", self.session_id,
+                     self._frame_count, self._completed_laps,
+                     ", wet" if wet else "",
+                     f", track={track} (auto)" if track else "")
         self.session_id = None
         self._race_off_since = None
         self._lap_number = None
@@ -463,7 +571,33 @@ class SessionTracker:
         self._air_since = None
         self._landing_grace_until = 0.0
         self._over_impact = False
+        self._route_id = None
+        self._geometric_laps = 0
+        self._prev_on_line = True
+        self._air_on_line = True
+        self._trk_prev = None
+        self._trk_drive_s = 0.0
+        self._trk_drive_n = 0
+        self._trk_corner_n = 0
+        self._trk_rough_n = 0
+        self._trk_rough_hi = 0
+        self._trk_jumps = 0
         self._lap_flags = set()
+
+    def _suggest_track(self) -> str | None:
+        """Track type to auto-fill at session close: the route's existing tag
+        first (routes don't change surface, and this propagates the user's
+        own corrections), the telemetry classification otherwise. The store
+        writes it with COALESCE, so it never overwrites a user tag."""
+        if self._route_id is not None:
+            inherited = self.store.route_track_type(self._route_id, self.session_id)
+            if inherited:
+                return inherited
+        return suggest_track_type(
+            geometric_laps=self._geometric_laps, drive_s=self._trk_drive_s,
+            drive_n=self._trk_drive_n, corner_n=self._trk_corner_n,
+            rough_n=self._trk_rough_n, rough_hi=self._trk_rough_hi,
+            jumps=self._trk_jumps)
 
     def _point_to_point_run_time(self) -> float | None:
         """Run time for an open lap in a session that ended without ever
@@ -495,6 +629,7 @@ class SessionTracker:
                     self._lap_start_pos[0], self._lap_start_pos[1], length)
                 self.store.set_session_route(self.session_id, rid)
                 self._route_assigned = True
+                self._route_id = rid
         self._lap_id = None
 
     def _ptp_run_time_at_cutoff(self) -> float | None:
@@ -802,6 +937,7 @@ class SessionTracker:
                  " from the launch point%s)", self.session_id,
                  self._completed_laps + 1, lap_time, d,
                  ", finalized at stream end" if frame is None else "")
+        self._geometric_laps += 1  # loop closure to the anchor: reads as wtc
         self._complete_current_lap(bt, lap_time, self._lap_number)
         if frame is None:
             self._lap_id = None  # session is ending: nothing to reopen
@@ -858,6 +994,7 @@ class SessionTracker:
             self._lap_start_pos[0], self._lap_start_pos[1], self._cur_d[-1])
         self.store.set_session_route(self.session_id, route_id)
         self._route_assigned = True
+        self._route_id = route_id
 
     def _delta(self, lap_dist: float, cur: float) -> float | None:
         if not self._ref_d or cur <= 0 or lap_dist <= 0:

--- a/app/recorder/reprocess.py
+++ b/app/recorder/reprocess.py
@@ -20,7 +20,10 @@ log = logging.getLogger("lapscope.recorder")
 class _ReplayStore:
     """Store facade for replays: laps and routes are written for real, but
     the session row itself is left alone - no create/end/discard, and the
-    frames are not rewritten."""
+    frames are not rewritten. The one exception: auto-detected tags (wet,
+    suggested track type) do apply, so a reprocess back-fills sessions
+    recorded before the detection existed - their COALESCE writes never
+    overwrite a tag the user set."""
 
     def __init__(self, store, session_id: int) -> None:
         self._store = store
@@ -38,8 +41,10 @@ class _ReplayStore:
         pass
 
     def end_session(self, session_id: int, ended_at: float, frame_count: int,
-                    conditions: str | None = None) -> None:
-        pass
+                    conditions: str | None = None,
+                    track_type: str | None = None) -> None:
+        if conditions or track_type:  # timing/frame_count stay untouched
+            self._store.auto_tag_session(self._sid, conditions, track_type)
 
     def discard_session(self, session_id: int) -> None:
         pass  # never delete the real session from a replay

--- a/app/recorder/store.py
+++ b/app/recorder/store.py
@@ -134,13 +134,42 @@ class Store:
         return sid
 
     def end_session(self, session_id: int, ended_at: float, frame_count: int,
-                    conditions: str | None = None) -> None:
+                    conditions: str | None = None,
+                    track_type: str | None = None) -> None:
+        # COALESCE: auto-detected tags (wet, suggested track type) never
+        # overwrite a value the user already set
         self.db.execute(
             "UPDATE sessions SET ended_at = ?, frame_count = ?,"
-            " conditions = COALESCE(conditions, ?) WHERE id = ?",
-            (ended_at, frame_count, conditions, session_id),
+            " conditions = COALESCE(conditions, ?),"
+            " track_type = COALESCE(track_type, ?) WHERE id = ?",
+            (ended_at, frame_count, conditions, track_type, session_id),
         )
         self.db.commit()
+
+    def auto_tag_session(self, session_id: int, conditions: str | None,
+                         track_type: str | None) -> None:
+        """Fill auto-detected tags without touching anything else (replays
+        use this - the session row's timing must stay untouched); COALESCE
+        keeps whatever the user already set."""
+        self.db.execute(
+            "UPDATE sessions SET conditions = COALESCE(conditions, ?),"
+            " track_type = COALESCE(track_type, ?) WHERE id = ?",
+            (conditions, track_type, session_id),
+        )
+        self.db.commit()
+
+    def route_track_type(self, route_id: int,
+                         exclude_session_id: int | None = None) -> str | None:
+        """Latest track type any other session on this route carries (manual
+        or auto). Event-loop connection: the tracker asks at session close."""
+        row = self.db.execute(
+            "SELECT track_type FROM sessions WHERE route_id = ?"
+            " AND track_type IS NOT NULL AND id != ?"
+            " ORDER BY started_at DESC LIMIT 1",
+            (route_id,
+             exclude_session_id if exclude_session_id is not None else -1),
+        ).fetchone()
+        return row[0] if row else None
 
     def discard_session(self, session_id: int) -> None:
         """Delete a just-ended session that produced no completed laps."""
@@ -265,6 +294,24 @@ class Store:
             cur = conn.execute("UPDATE routes SET name = ? WHERE id = ?", (name, route_id))
             conn.commit()
             return cur.rowcount > 0
+
+    def route_exists(self, route_id: int) -> bool:
+        with self.reader() as conn:
+            return conn.execute("SELECT 1 FROM routes WHERE id = ?",
+                                (route_id,)).fetchone() is not None
+
+    def set_route_sessions_track_type(self, route_id: int,
+                                      track_type: str | None) -> int:
+        """Retag every session on a route at once (the analysis page's
+        "apply to all sessions on this route?" prompt). Overwrites existing
+        tags on purpose - the user just confirmed exactly that. Returns the
+        number of sessions updated."""
+        with self.reader() as conn:
+            cur = conn.execute(
+                "UPDATE sessions SET track_type = ? WHERE route_id = ?",
+                (track_type, route_id))
+            conn.commit()
+            return cur.rowcount
 
     def set_car_name(self, ordinal: int, name: str) -> None:
         with self.reader() as conn:

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -105,7 +105,11 @@ async function selectSession(id) {
   $("#cond-select").value = s.conditions || "";
   $("#cond-select").onchange = async (e) => { await patch({ conditions: e.target.value }); loadSessions(); };
   $("#track-select").value = s.track_type || "";
-  $("#track-select").onchange = async (e) => { await patch({ track_type: e.target.value }); loadSessions(); };
+  $("#track-select").onchange = async (e) => {
+    await patch({ track_type: e.target.value });
+    await maybeRetagRoute(s, e.target.value);
+    loadSessions();
+  };
   $("#btn-rename").onclick = () => renameSession(s);
   $("#btn-route").onclick = () => renameRoute(s);
   $("#btn-car").onclick = () => renameCar(s);
@@ -222,6 +226,26 @@ async function renameRoute(session) {
     body: JSON.stringify({ name: name.trim() }),
   });
   selectSession(session.id);
+}
+
+/* a route's surface doesn't change: offer to apply a manually chosen track
+   type to every session recorded on the same (fingerprint-recognized) route */
+async function maybeRetagRoute(session, type) {
+  if (!type || !session.route_id) return;
+  const all = await (await fetch("/api/sessions")).json();
+  const others = all.filter((x) => x.route_id === session.route_id && x.id !== session.id);
+  if (!others.length) return;
+  const [icon, label] = TRACK_META[type];
+  const route = session.route_name || "this route";
+  const ok = await uiConfirm(`Tag every session on ${route} as ${icon} ${label}?`,
+    `${others.length} other session${others.length > 1 ? "s" : ""} recorded on the same route`
+    + " will be retagged too (future sessions inherit it automatically).");
+  if (!ok) return;
+  await fetch(`/api/routes/${session.route_id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ track_type: type }),
+  });
 }
 
 async function renameCar(session) {

--- a/app/static/js/common.js
+++ b/app/static/js/common.js
@@ -83,7 +83,9 @@ function condBadge(cond) {
   return `<span class="cond-badge cond-${cond}">${icon} ${label}</span>`;
 }
 
-/* course/track type is not in the packet - manual tag like snow/dirt */
+/* course/track type is not in the packet - the recorder auto-suggests one at
+   session close (road/dirt/cross/wtc, from surface + geometry evidence) and
+   the user can always override; street/touge/drag stay manual-only */
 const TRACK_META = {
   road: ["🛣️", "Road"],
   street: ["🏙️", "Street"],

--- a/docs/wiki/Event-Detection.md
+++ b/docs/wiki/Event-Detection.md
@@ -168,6 +168,37 @@ The game never sends route names, so circuits are **fingerprinted**: same
 start position within 80 m + lap length within 5 % = same route. Name a route
 once and every past and future session on it picks the name up.
 
+## Track type: auto-suggested, always yours to override
+
+The track-type tag (🛣️ road, 🏙️ street, ⛰️ touge, 🟫 dirt, 🏞️ cross-country,
+🏁 drag, ⏱️ WTC) is pre-filled at session close when the evidence is clear —
+it stays a manual tag with a smart default, and your dropdown choice always
+wins. The suggestion comes from, strongest first:
+
+1. **The route's existing tag.** A route's surface doesn't change, so any tag
+   already carried by another session on the same fingerprinted route is
+   reused — including your own corrections. Changing a session's type also
+   offers to retag every session on its route in one click.
+2. **Geometric laps → WTC.** Laps found by loop closure back to the launch
+   anchor (see above) only happen in World Time Attack.
+3. **Surface evidence → dirt / cross-country / road.** Calibrated on real
+   captures: dirt courses shake the suspension hard (10–16 % "rough" frames
+   vs. under 3 % on any tarmac course) at a low jump rate; cross-country
+   flies a crest every few hundred meters (≥ ~5 jumps/min); smooth suspension
+   with no jumps is tarmac → road. Notably, **tire slip does not work** for
+   this — it tracks driver aggression, not the ground (hard tarmac laps
+   out-slip clean dirt runs).
+
+Frames far off the course (`NormalizedDrivingLine` saturated at ±127) are
+excluded from the surface evidence, so deliberately off-roading a tarmac
+event can't fake a dirt tag. Street and touge read as tarmac (suggested
+road — correct once, the route remembers); drag strips have almost no
+cornering and are deliberately left untagged. When the evidence is thin or
+sits between classes, no tag is suggested at all.
+
+Reprocessing an old session back-fills its suggestion the same way — without
+ever overwriting a tag you set yourself.
+
 ## Reprocess: inference fixes apply retroactively
 
 Recordings are lossless raw packets, so the **Reprocess** button replays a

--- a/docs/wiki/FH6-Data-Out-Packet.md
+++ b/docs/wiki/FH6-Data-Out-Packet.md
@@ -66,6 +66,17 @@ These are the facts that shaped the app — each one broke a naive assumption:
   give a heading. **`Yaw` is world-space** — the car moves along
   `(sin yaw, cos yaw)` in world X/Z (verified against position deltas).
 - **`TireTemp` is Fahrenheit**, whatever your in-game units.
+- **`TireCombinedSlip` tracks driver aggression, not the surface.** Across the
+  stored real captures, hard-driven tarmac laps sustain *more* combined slip
+  than clean dirt runs — so surface detection (the auto-suggested track type)
+  reads suspension roughness and jump rate instead.
+- **`NormalizedDrivingLine` saturates at ±127 far off the course.** During
+  events it sits mid-range 73–97 % of frames on every surface (dirt courses
+  have a driving line too); the saturated frames are the off-course moments.
+  LapScope uses that as an on-course gate: off-line frames contribute no
+  surface evidence, so off-roading a tarmac event can't fake a dirt tag.
+  (`NormalizedAIBrakeDifference` was checked too — ~0 on most frames, no
+  useful signal.)
 - `DrivetrainType`: 0 = FWD, 1 = RWD, 2 = AWD.
 - `CarClass` indexes into **D, C, B, A, S1, S2, R, X** — the **R class is new
   in FH6** (901–998 PI; X is 999 only, verified on a real 998 car).

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,6 +142,67 @@ def test_session_name_patch_sets_and_clears(tmp_path):
     assert store.get_session(sid)["name"] is None
 
 
+def test_track_type_patch_overrides_auto_and_clears(tmp_path):
+    """The dropdown always wins over the auto-suggested type (the suggestion
+    is written with COALESCE at session close, a PATCH overwrites), and ""
+    clears back to untagged."""
+    from app.api.routes import SessionPatch, patch_session
+
+    def scenario(sim):
+        sim.event(120, "event")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    sid = sessions(store)[0]["id"]
+    assert store.get_session(sid)["track_type"] == "road"  # auto-filled
+    req = _request_for(store)
+
+    patch_session(sid, SessionPatch(track_type="street"), req)
+    assert store.get_session(sid)["track_type"] == "street"
+
+    patch_session(sid, SessionPatch(track_type=""), req)
+    assert store.get_session(sid)["track_type"] is None
+
+
+def test_route_patch_retags_every_session_on_the_route(tmp_path):
+    """PATCH /routes/{id} with track_type retags all sessions of that route
+    (the "apply to all sessions on this route?" prompt), rejects unknown
+    types and routes, and renaming still works through the same endpoint."""
+    from app.api.routes import RoutePatch, patch_route
+
+    def scenario(sim):
+        for i in range(2):
+            sim.event(75, f"event {i + 1}")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    ss = sessions(store)
+    rid = ss[0]["route_id"]
+    assert len(ss) == 2 and all(s["track_type"] == "road" for s in ss)
+    req = _request_for(store)
+
+    patch_route(rid, RoutePatch(track_type="touge"), req)
+    assert all(s["track_type"] == "touge" for s in sessions(store))
+
+    patch_route(rid, RoutePatch(name="Bandai Azuma"), req)
+    assert sessions(store)[0]["route_name"] == "Bandai Azuma"
+
+    with pytest.raises(HTTPException) as exc:
+        patch_route(rid, RoutePatch(track_type="gravel"), req)
+    assert exc.value.status_code == 400
+
+    with pytest.raises(HTTPException) as exc:
+        patch_route(rid + 99, RoutePatch(track_type="road"), req)
+    assert exc.value.status_code == 404
+
+
+def test_suggestions_are_valid_track_types():
+    """Cross-file invariant: everything the classifier can suggest must be a
+    member of the API's TRACK_TYPES (= TRACK_META = #track-select)."""
+    from app.api.routes import TRACK_TYPES
+    assert {"road", "dirt", "cross", "wtc"} <= TRACK_TYPES
+
+
 def test_reprocess_blocked_while_any_session_records(tmp_path):
     """The replay runs synchronously on the event loop, so reprocess must 409
     while ANY session is recording - not only when the target session is the

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -174,6 +174,80 @@ def test_wta_cut_dead_at_line(tmp_path):
     assert flags_of(timed[0]) == "" and flags_of(timed[1]) == ""
 
 
+def test_track_type_circuit_suggests_road(tmp_path):
+    """A tarmac circuit (smooth suspension, no jumps) is auto-tagged road at
+    session close."""
+    def scenario(sim):
+        sim.event(150, "event")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    assert sessions(store)[0]["track_type"] == "road"
+
+
+def test_track_type_sprint_suggests_road(tmp_path):
+    """--sprint 75: a tarmac point-to-point run reads road too."""
+    def scenario(sim):
+        sim.sprint(75)
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    assert sessions(store)[0]["track_type"] == "road"
+
+
+def test_track_type_dirt_sprint_suggests_dirt(tmp_path):
+    """--dirt 60: washboard suspension at a low jump rate = dirt."""
+    def scenario(sim):
+        sim.dirt_sprint(60)
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    assert sessions(store)[0]["track_type"] == "dirt"
+
+
+def test_track_type_cross_country(tmp_path):
+    """--dirt 60 --jumps: the same dirt surface flying a crest every few
+    hundred meters = cross-country."""
+    def scenario(sim):
+        sim.dirt_sprint(60)
+        sim.race_off()
+
+    store = run(scenario, tmp_path, jumps=True)
+    assert sessions(store)[0]["track_type"] == "cross"
+
+
+def test_track_type_wta_suggests_wtc(tmp_path):
+    """--wta 3: geometric laps (loop closure back to the launch anchor) =
+    wtc, whatever the surface evidence says."""
+    def scenario(sim):
+        sim.wta(3)
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    assert sessions(store)[0]["track_type"] == "wtc"
+
+
+def test_track_type_route_inheritance_beats_telemetry(tmp_path):
+    """A tag already on the route wins over the telemetry verdict: correct a
+    course once (e.g. to touge) and every later session on it inherits."""
+    def scenario(sim):
+        sim.event(75, "event")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    first = sessions(store)[0]
+    assert first["track_type"] == "road"                # the telemetry verdict
+    store.set_session_track_type(first["id"], "touge")  # the user corrects it
+
+    store = run(scenario, tmp_path)                     # same DB -> same route
+    ss = sessions(store)
+    assert len(ss) == 2
+    # ids are monotonic; started_at can tie under the harness's restarted clock
+    newest = max(ss, key=lambda s: s["id"])
+    assert newest["id"] != first["id"]
+    assert newest["track_type"] == "touge"              # inherited, not re-derived
+
+
 def test_jumps_do_not_break_a_point_to_point_run(tmp_path):
     """--sprint 75 --jumps: cross-country-style elevation spikes still record
     a single clean run (3D-map scaling is a frontend concern). The jumps go

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import math
 from pathlib import Path
 
-from app.recorder.laps import SessionTracker
+from app.recorder.laps import SessionTracker, suggest_track_type
 from app.recorder.store import Store
 from app.telemetry.packet import empty_fields, pack, parse
 
@@ -181,6 +181,75 @@ def test_race_mode_drops_at_lastlap_finish(tmp_path):
 
     timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
     assert [lap["lap_time"] for lap in timed] == [62.0, 61.5]
+
+
+def test_suggest_track_type_matrix():
+    """The calibrated decision tree (thresholds swept from real captures):
+    each class from its evidence, None whenever the evidence is thin,
+    drag-like, or in the gap zone between surfaces."""
+    base = dict(geometric_laps=0, drive_s=120.0, drive_n=7200, corner_n=3000,
+                rough_n=7000, rough_hi=0, jumps=0)
+    assert suggest_track_type(**base) == "road"
+    assert suggest_track_type(**{**base, "rough_hi": 1000, "jumps": 4}) == "dirt"
+    assert suggest_track_type(**{**base, "jumps": 12}) == "cross"
+    assert suggest_track_type(**{**base, "geometric_laps": 2}) == "wtc"
+    assert suggest_track_type(**{**base, "corner_n": 100}) is None   # drag-like
+    assert suggest_track_type(**{**base, "rough_hi": 400}) is None   # gap zone
+    assert suggest_track_type(**{**base, "drive_s": 20.0}) is None   # too little
+
+
+def _course_drive(d: Driver, n: int, rough: bool, on_line: bool) -> None:
+    """n frames of fast, twisty driving: smooth tarmac or washboard-rough,
+    on or off the course line (NormalizedDrivingLine saturates at 127 far
+    off course)."""
+    for i in range(n):
+        d.send(current_lap=d.f["current_lap"] + 1 / 60,
+               distance_traveled=d.f["distance_traveled"] + 1.0,
+               speed=60.0, steer=60 if i % 2 else -60,
+               normalized_driving_line=0 if on_line else 127,
+               norm_susp_travel=[0.5 + (0.06 if rough and i % 2 else 0.0)] * 4,
+               tire_combined_slip=[0.3] * 4, accel_x=0.0)
+
+
+def _fly(d: Driver, frames: int, on_line: bool) -> None:
+    """A flight (all wheels unloaded); whether it counts as a jump depends
+    on the frame it launched FROM being on the course line."""
+    for _ in range(frames):
+        d.send(current_lap=d.f["current_lap"] + 1 / 60,
+               distance_traveled=d.f["distance_traveled"] + 1.0,
+               speed=60.0, normalized_driving_line=0 if on_line else 127,
+               **AIR)
+
+
+def _finish_event_track_type(d: Driver) -> str | None:
+    """Cross the line to complete the run, close the session, and return the
+    auto-suggested track type."""
+    d.send(lap_number=1, current_lap=0.0, last_lap=50.0, speed=60.0, **GROUND)
+    d.finish()
+    return d.store.get_session(1)["track_type"]
+
+
+def test_rough_driving_with_jumps_reads_dirt(tmp_path):
+    """Washboard suspension + an occasional flight, all on the course line:
+    the session is auto-tagged dirt (control for the off-line gate below)."""
+    d = Driver(tmp_path)
+    for _ in range(2):
+        _course_drive(d, 25 * 60, rough=True, on_line=True)
+        _fly(d, 20, on_line=True)
+    assert _finish_event_track_type(d) == "dirt"
+
+
+def test_off_line_roughness_cannot_fake_dirt(tmp_path):
+    """The anti-troll gate: a tarmac event with deliberate off-road
+    excursions (driving line saturated while bouncing through the grass,
+    jumping ditches) still reads road - off-line frames and off-line
+    takeoffs contribute no surface evidence."""
+    d = Driver(tmp_path)
+    for _ in range(2):
+        _course_drive(d, 25 * 60, rough=False, on_line=True)  # tarmac proper
+        _course_drive(d, 8 * 60, rough=True, on_line=False)   # grass excursion
+        _fly(d, 20, on_line=False)                            # ditch jump
+    assert _finish_event_track_type(d) == "road"
 
 
 def test_listener_fallback_keeps_frame_contract(tmp_path):

--- a/tools/simulator.py
+++ b/tools/simulator.py
@@ -83,6 +83,12 @@ def sprint_curv(s: float) -> float:
 
 JUMPS = False  # set by --jumps: sharp elevation spikes like cross-country jumps
 JUMP_BUMPS = ((300.0, 25.0, 11.0), (1500.0, 30.0, 16.0))  # center, width, height
+# open (point-to-point) courses place crests far denser than the loop's two
+# bumps: a cross-country sprint flies every few hundred meters, and the
+# recorder's track-type suggestion reads exactly that jump rate
+OPEN_JUMP_PERIOD = 600.0
+OPEN_JUMP_BUMP = (300.0, 25.0, 11.0)
+DIRT_AIR_SPACING = 30.0  # s between the small whoop flights of a dirt course
 
 
 def track_elevation(s: float) -> float:
@@ -141,6 +147,10 @@ class Sim:
     air_frames = 0     # jump flight in progress (all wheels unloaded)
     land_frames = 0    # touchdown jolt frames right after a flight
     _prev_sp = None
+    surface = "tarmac"       # dirt_sprint switches to "dirt": washboard
+                             # suspension + whoop flights (what the recorder's
+                             # track-type suggestion reads as a dirt course)
+    _next_whoop = None       # race clock of the next dirt whoop flight
 
     def _send(self, race_time: float, lap_no: int, cur_lap: float,
               last: float, best: float) -> None:
@@ -166,27 +176,39 @@ class Sim:
         # landing, not contact
         airborne, vert_a = False, 0.2
         if JUMPS:
-            sp = self.s % PERIMETER
+            period = OPEN_JUMP_PERIOD if self.open_course else PERIMETER
+            bumps = (OPEN_JUMP_BUMP,) if self.open_course else JUMP_BUMPS
+            sp = self.s % period
             if self.air_frames == 0 and self.land_frames == 0 and self._prev_sp is not None:
-                # crest crossed this frame (wrap = sp collapsed by ~a lap;
+                # crest crossed this frame (wrap = sp collapsed by ~a period;
                 # a rewind scrub moves backwards in small steps and must not
                 # launch the car)
-                wrapped = self._prev_sp - sp > PERIMETER / 2
-                for c, _w, _h in JUMP_BUMPS:
+                wrapped = self._prev_sp - sp > period / 2
+                for c, _w, _h in bumps:
                     if ((self._prev_sp < c <= sp)
                             or (wrapped and (self._prev_sp < c or c <= sp))):
                         self.air_frames = int(round(0.4 / self.dt))
             self._prev_sp = sp
-            if self.air_frames > 0:
-                self.air_frames -= 1
-                airborne = True
-                lat_a, vert_a = 0.0, -12.0  # free fall, no tire grip
-                if self.air_frames == 0:
-                    self.land_frames = 2
-            elif self.land_frames > 0:
-                self.land_frames -= 1
-                lat_a += 75.0  # touchdown jolt in the ground plane
-                vert_a = 160.0
+        # dirt whoops: brief flights every DIRT_AIR_SPACING seconds of the
+        # run - the steady low jump rate of a real dirt trail (well under
+        # cross-country's crest-every-few-hundred-meters rate)
+        if (self.surface == "dirt" and self.air_frames == 0
+                and self.land_frames == 0):
+            if self._next_whoop is None:
+                self._next_whoop = race_time + DIRT_AIR_SPACING / 2
+            elif race_time >= self._next_whoop:
+                self.air_frames = int(round(0.25 / self.dt))
+                self._next_whoop = race_time + DIRT_AIR_SPACING
+        if self.air_frames > 0:
+            self.air_frames -= 1
+            airborne = True
+            lat_a, vert_a = 0.0, -12.0  # free fall, no tire grip
+            if self.air_frames == 0:
+                self.land_frames = 2
+        elif self.land_frames > 0:
+            self.land_frames -= 1
+            lat_a += 75.0  # touchdown jolt in the ground plane
+            vert_a = 160.0
         grip_used = math.hypot(lat_a / GRIP_LAT, self.lon_a / BRAKE_MAX)
         slip = 0.0 if airborne else max(0.0, grip_used + random.uniform(-0.05, 0.05))
 
@@ -210,15 +232,14 @@ class Sim:
             # here movement is (cos heading, sin heading), so yaw = pi/2 - heading
             vel_x=0.0, vel_z=self.v,
             ang_vel_y=self.v * curv, yaw=math.pi / 2 - heading,
-            norm_susp_travel=[0.0] * 4 if airborne else
-                [min(1.0, 0.45 + 0.3 * abs(lat_a) / GRIP_LAT + 0.1 * random.random())] * 4,
+            norm_susp_travel=self._susp(lat_a, airborne),
             tire_slip_ratio=[slip * 0.6] * 4,
             wheel_rotation_speed=[self.v / 0.33] * 4,
             wheel_in_puddle=puddle,
             tire_slip_angle=[slip * front_bias, slip * front_bias, slip * 0.9, slip * 0.9],
             tire_combined_slip=[slip * front_bias, slip * front_bias, slip * 0.92, slip * 0.92],
             susp_travel_meters=[-0.08] * 4 if airborne else [0.06] * 4,
-            pos_x=x, pos_y=track_elevation(self.s), pos_z=z,
+            pos_x=x, pos_y=self._elevation(), pos_z=z,
             speed=self.v, power=torque * rpm * math.tau / 60, torque=torque,
             tire_temp=[160 + 90 * slip + random.uniform(-3, 3) for _ in range(4)],
             boost=throttle / 255 * 14.0,
@@ -227,12 +248,38 @@ class Sim:
             current_race_time=race_time, lap_number=lap_no,
             accel=throttle, brake=brake,
             steer=int(max(-127, min(127, curv * RADIUS * 90))), gear=gear,
+            # racing on the course proper: the driving line tracks a small
+            # lateral offset (|127| would mean far off the course)
+            normalized_driving_line=int(20 * math.sin(self.s / 90.0)),
         )
         self.sock.sendto(pack(f), self.target)
         self.sent += 1
         lag = self.t0 + self.sent * self.dt - time.monotonic()
         if lag > 0:
             time.sleep(lag)
+
+    def _susp(self, lat_a: float, airborne: bool) -> list[float]:
+        """Suspension travel: full droop in flight; smooth on tarmac (real
+        tarmac captures show <3 % rough frames - white noise here would read
+        as dirt to the recorder's track-type suggestion); washboard jitter
+        on dirt (real dirt captures: 10-16 % rough frames)."""
+        if airborne:
+            return [0.0] * 4
+        base = (0.45 + 0.3 * abs(lat_a) / GRIP_LAT
+                + 0.05 * math.sin(self.s / 40.0) + 0.01 * random.random())
+        if self.surface == "dirt":
+            base += random.uniform(0.0, 0.08)
+        return [min(1.0, base)] * 4
+
+    def _elevation(self) -> float:
+        """pos_y matching where the flights launch: the loop's two bumps, or
+        the denser crests of an open course under --jumps."""
+        if JUMPS and self.open_course:
+            sp = self.s % OPEN_JUMP_PERIOD
+            c, w, h = OPEN_JUMP_BUMP
+            return (105.0 + 6.0 * math.sin(self.s / 400.0)
+                    + h * math.exp(-(((sp - c) / w) ** 2)))
+        return track_elevation(self.s)
 
     def freeroam(self, seconds: float) -> None:
         """Cruise: lap fields all zero, free-roam clock counting, no grid
@@ -441,6 +488,8 @@ class Sim:
         self.total_dist = 0.0
         self.f["race_position"] = random.randint(2, 8)
         self.open_course = True
+        self.surface = "dirt"     # washboard suspension + whoop flights
+        self._next_whoop = None
         self._oc_x, self._oc_z, self._oc_s = -STRAIGHT / 2, -RADIUS, 0.0
         self.pace = random.uniform(0.97, 1.0)
         t = 0.0


### PR DESCRIPTION
Closes #28

The track-type tag now fills itself in at session close — it stays a manual tag, just with a smart default. Written with COALESCE, so a user-set tag always wins.

## How the suggestion is made (strongest signal first)

1. **Route inheritance** — a tag already carried by another session on the same fingerprinted route is reused (routes don't change surface; this also propagates manual corrections).
2. **Geometric laps → `wtc`** — loop closure back to the launch anchor only happens in World Time Attack.
3. **Surface evidence → `dirt` / `cross` / `road`** — suspension roughness + jump rate, calibrated on the stored real captures (dump → hand-label → DB sweep, same method as the landing classifier). Thin or ambiguous evidence → no tag; near-zero cornering (drag strips) → no tag; `street`/`touge` read as tarmac → suggested `road` (correct once, the route remembers).

## Findings from the calibration sweep

- **`TireCombinedSlip` does NOT discriminate surface** — it tracks driver aggression: hard tarmac laps sustain more slip than clean dirt runs. Ruled out; roughness + jump rate separate the labeled captures cleanly (dirt: 10–16 % rough frames at 1.0–2.5 jumps/min; tarmac: ≤3 % at ~0; cross-country: ≥4.9 jumps/min).
- **`NormalizedDrivingLine` saturates at ±127 far off the course** — used as the anti-troll gate: off-line frames and off-line takeoffs contribute no surface evidence, so deliberately off-roading a tarmac event can't fake a dirt tag. (`NormalizedAIBrakeDifference` carries no usable signal.)
- Validation replay over every stored capture: **9/9 labeled sessions matched, 0 hard mismatches**; the unlabeled Shimanoyama sessions all read `cross`, the untagged Hokubu WTA runs `wtc`.

## Also in this PR

- **Route-wide retag**: changing a session's type offers "tag every session on this route?" (`PATCH /routes/{id}` grew an optional `track_type`; `""` clears them all).
- **Reprocess back-fills** suggestions on old sessions (`_ReplayStore` now applies auto-tags only — timing/frame_count stay untouched, user tags never overwritten).
- **Simulator surface modeling**: smooth tarmac suspension (the old white noise read rougher than real dirt), washboard + whoop flights on dirt, denser crests on open courses under `--jumps`, an on-course driving line — so the five new scenario-matrix rows run headless like the rest.
- Docs: AGENTS.md (packet facts + detection model + test matrix), ARCHITECTURE.md, README, wiki Event-Detection + FH6-Data-Out-Packet pages.

## Verified

- `pytest -q` 55/55, `ruff check .` clean, packet self-test OK.
- Live against the rebuilt container: a simulated dirt sprint closed as `track=dirt (auto)` with the 🟫 badge and pre-selected dropdown; a second run on the same route inherited a manually-corrected `touge` tag; the retag modal propagated to the whole route and left other routes untouched.