### PR TITLE
feat: manual session editing — dismiss contact markers, re-tag laps, exclude laps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,16 @@ All the rules exist because some real behavior broke a naive version:
   detection fix. Must stay `async def` (writes on the event-loop connection),
   which also means the replay blocks the loop — it 409s while **any** session
   is recording, or a long replay would freeze live telemetry mid-race.
+- **Manual edits are read-time overrides** (analysis page: dismiss a contact
+  marker, re-tag a lap's flags, exclude a lap from bests/counts). They live in
+  the `edits` table keyed by **frame timestamps, never lap ids** — a reprocess
+  deletes and recreates lap rows (SQLite reuses the rowids!), so id-keyed
+  edits would silently attach to the wrong laps; time-keyed ones re-apply to
+  the rebuilt laps by design (they're user intent). Raw frames and the
+  recorder's `laps.flags` are never rewritten; `Store.session_laps` merges the
+  overrides in (`flags` effective, `flags_auto` detected, `excluded`), and
+  `DELETE /api/sessions/{id}/edits` ("Reset edits") is the escape hatch back
+  to pure detection.
 - `sessions.kept = 1` exempts a session from the startup no-laps cleanup
   (LS_KEEP_DISCARDED captures and reprocessed sessions set it).
 - Dirty-lap inference: rewind = lap clock below its high-water mark while

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 | [app/telemetry/listener.py](app/telemetry/listener.py) | `asyncio.DatagramProtocol`: counts packets, warns once on wrong size (hex dump), parses, feeds tracker, publishes frame+extras to hub. Recorder exceptions never kill the stream. |
 | [app/telemetry/hub.py](app/telemetry/hub.py) | Fan-out to WebSocket subscriber queues (drop-oldest on slow clients) + stream stats used by `/api/status`. |
 | [app/recorder/laps.py](app/recorder/laps.py) | **The heart.** `SessionTracker`: session boundaries, lap segmentation, finish detection, geometric (WTA) laps, dirty-lap flags, wet detection, route fingerprint triggers, live delta, `race_mode`, and the track-type auto-suggestion (`suggest_track_type` + per-frame surface accumulators; written at session close with COALESCE so user tags win). All tunable thresholds are module constants at the top. |
-| [app/recorder/store.py](app/recorder/store.py) | SQLite persistence: schema, `MIGRATIONS`, session/lap/route/car-name CRUD, monotonic session-id counter, `reader()` for threadpool access. |
+| [app/recorder/store.py](app/recorder/store.py) | SQLite persistence: schema, `MIGRATIONS`, session/lap/route/car-name CRUD, manual-edit overrides (`edits` table, merged into `session_laps` at read time), monotonic session-id counter, `reader()` for threadpool access. |
 | [app/recorder/reprocess.py](app/recorder/reprocess.py) | Replays a session's stored raw frames through a fresh `SessionTracker` via `_ReplayStore` (laps/routes written for real; session row and frames untouched; discard suppressed). |
 | [app/api/routes.py](app/api/routes.py) | REST API (table below) + constants: `CAR_CLASSES`, `CONDITIONS`, `TRACK_TYPES`, `DRIVETRAINS`, `CHANNELS` (channel-name → frame extractor for lap data). |
 | [app/cars.py](app/cars.py) | Community car-name list (`CarOrdinal` → name), three layers, top wins: `car_names` DB override > downloaded `DATA_DIR/car_ordinals.json` > bundled `app/car_ordinals.json`. `refresh()` re-downloads the maintained copy from this repo's `main` (validated, atomically persisted, hot-swapped); triggered by the browser daily + Settings "Refresh now" via `POST /api/cars/refresh`. |
@@ -54,9 +54,17 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 - `routes(id, name, start_x, start_z, lap_length)` — fingerprint: start within
   80 m + length within 5 %.
 - `car_names(ordinal, name)` — user overrides of the bundled ordinal list.
+- `edits(id, session_id→sessions CASCADE, kind, anchor_t, value, created_at)`
+  — manual session edits, applied at read time (raw frames and the recorder's
+  lap rows are never rewritten). `kind`: `dismiss_contact` (anchor = the
+  collision peak's frame time, matched ±0.5 s), `flags` (`value` = the full
+  flags CSV, `""` = none) and `exclude_lap` (both anchored at the lap-span
+  midpoint). Keyed by frame time so a reprocess — which recreates lap rows
+  under recycled rowids — keeps them.
 
 Schema changes: append `ALTER TABLE ... ADD COLUMN` to `store.MIGRATIONS`;
 each runs on every startup inside try/except (existing-column errors swallowed).
+New tables go straight into `SCHEMA` (`CREATE TABLE IF NOT EXISTS` is idempotent).
 
 ## REST API (`/api`)
 
@@ -66,10 +74,13 @@ each runs on every startup inside try/except (existing-column errors swallowed).
 | `GET /version` | `{"version": app.__version__}` — the running build. The frontend compares it (client-side) against the latest GitHub Release for the update notice; `"0.0.0"` (dev/source run) suppresses the check. |
 | `GET /sessions` | List with route/car-name joins, lap counts, best lap. |
 | `PATCH /sessions/{id}` | `name` (`""` clears → display falls back to route/date), `conditions` (`dry/wet/snow`, `""` clears), `track_type` (`road/street/touge/dirt/cross/drag/wtc`, `""` clears). |
-| `POST /sessions/{id}/reprocess` | Rebuild laps from stored frames (async def — event-loop writes). 409 while **any** session records: the synchronous replay would stall the event loop and freeze live telemetry. |
+| `POST /sessions/{id}/reprocess` | Rebuild laps from stored frames (async def — event-loop writes). 409 while **any** session records: the synchronous replay would stall the event loop and freeze live telemetry. Manual edits survive (time-keyed — see the `edits` table). |
 | `DELETE /sessions/{id}` | Cascades frames+laps. 409 while recording. |
-| `GET /sessions/{id}/laps` | Session + laps with `is_best` / `gap_to_best`. |
-| `GET /laps/{id}/data?channels=&max_points=` | Distance-indexed channel arrays; drops rewound-over samples; decimates to `max_points`. Channel names = `CHANNELS` keys in routes.py. `lap_time` falls back to time-since-lap-start when the packet lap clock never ran (WTA / bare sprints keep `CurrentLap` at 0), so the A/B Δ-time chart works for those events. Also returns `collisions` (contact-spike peaks, `landing: true/false`) and `jumps` (airborne segments: takeoff → touchdown world coords + `dist0/dist1`, `air_s`, `hard` + peak `g` when the landing spiked) — both computed on the full-resolution trace, never decimated away. |
+| `GET /sessions/{id}/laps` | Session + laps with `is_best` / `gap_to_best` (excluded laps never score). Each lap carries effective `flags`, detected `flags_auto`, `excluded`; the session carries `edit_count` (drives the Reset-edits button). |
+| `PATCH /laps/{id}` | Manual lap curation as read-time edits: `flags` (full CSV, `""` = none; a value equal to the detected flags removes the override), `excluded` (drop/restore from bests+counts). |
+| `POST /laps/{id}/dismiss_contact` | "Not a contact": body `{t}` from the collision list. 404 if no collision peak within ±0.5 s. Lifts the lap's `contact` flag once no real (non-landing, non-dismissed) contact remains — only ever removes flags. |
+| `DELETE /sessions/{id}/edits` | Reset edits: drops every manual edit of the session, back to pure detection. |
+| `GET /laps/{id}/data?channels=&max_points=` | Distance-indexed channel arrays; drops rewound-over samples; decimates to `max_points`. Channel names = `CHANNELS` keys in routes.py. `lap_time` falls back to time-since-lap-start when the packet lap clock never ran (WTA / bare sprints keep `CurrentLap` at 0), so the A/B Δ-time chart works for those events. Also returns `collisions` (contact-spike peaks, `landing: true/false`, `t` = the peak's frame time — the dismissal handle — and `dismissed: true` when a manual edit matched it) and `jumps` (airborne segments: takeoff → touchdown world coords + `dist0/dist1`, `air_s`, `hard` + peak `g` when the landing spiked) — both computed on the full-resolution trace, never decimated away. |
 | `PATCH /routes/{id}`, `GET/PATCH /cars/{ordinal}` | Route: `name` renames, `track_type` retags **every session on the route** at once (the analysis page offers this when a session's type is changed; `""` clears them all). Car override (`name: ""` reverts to the bundled/downloaded name). `GET` also returns `known` (ordinal resolvable without the `Car #<id>` fallback). |
 | `GET /cars`, `POST /cars/refresh` | Car-list metadata (`total`, `fetched_at`) / re-download the community list (see app/cars.py row above; 502 with a readable `detail` on failure — the current list stays). Registered before `/cars/{ordinal}` so `refresh` isn't parsed as an ordinal. |
 
@@ -86,7 +97,7 @@ listener: `session_id`, `delta` (vs session-best), `session_best`,
 |---|---|
 | `index.html` + `js/dashboard.js` | Live page: WebSocket → `requestAnimationFrame` render loop; live track map state (`feedLiveMap`: resets on session-id change or >250 m jump — except a pause-split resume: same place + race clock kept its value keeps the path; `feedCollision` also tracks jump flights); race-mode gating of timer/chip/map; no-data overlay polling `/api/status`. |
 | `js/gauges.js` | Pure canvas renderers (RPM arc, friction circle, grip panel, input strip, live map incl. jump glyphs); `initCanvas` handles DPR scaling. |
-| `analysis.html` + `js/analysis.js` | Session browser, lap table, 2D/3D track map (color by speed/slip, drag-to-rotate 3D, chart-hover → map marker, jump/contact layers, chart drag-zoom → highlighted span), A/B comparison charts (uPlot, x = DistanceTraveled track position; drag-zoom syncs across all charts, double-click resets). |
+| `analysis.html` + `js/analysis.js` | Session browser, lap table, 2D/3D track map (color by speed/slip, drag-to-rotate 3D, chart-hover → map marker, jump/contact layers, chart drag-zoom → highlighted span), A/B comparison charts (uPlot, x = DistanceTraveled track position; drag-zoom syncs across all charts, double-click resets). Manual editing: right-click a contact spark → dismiss, per-lap ✎ flags editor + 🗑/↩ exclude toggle in the lap table, Reset-edits header button (visible when `edit_count > 0`); `reloadSession()` refreshes after an edit without resetting the A/B picks. |
 | `js/common.js` | Shared badges (class/PI, drivetrain, conditions, track type incl. `TRACK_META`) + the `drawJump` canvas glyph both maps use + themed modal dialogs (`uiPrompt`/`uiConfirm`/`uiAlert` — never use `window.prompt/confirm/alert`) + the fail-soft client-side update check (`/api/version` vs the GitHub Releases API; dismissible `.update-banner`, 24 h cached, skipped on `0.0.0`) + the once-a-day car-list refresh trigger (`maybeRefreshCarList` → `POST /api/cars/refresh`) and `unknownCarIssueUrl` (pre-filled `unknown_car.yml` issue). |
 | `js/settings.js` | User display preferences, `localStorage`-only (no backend — conversions are display-time, the recorder stores raw packets). One JSON key `ls_settings`; converters (`speedFromMps`/`speedFromKmh`/`speedUnit`, `tempFromF`/`tempUnit`/`fmtTireTemp`, `distFromM`/`distUnit`); `getSettings`/`saveSettings`/`onSettingsChange` pub-sub; `openSettings()` themed panel (reuses `common.js` modal chrome). Loaded after `common.js` on both pages; the ⚙ header button (`#settings-btn`) opens it. |
 | `css/style.css` | Theme = CSS custom props. `css/fonts.css` + `fonts/` = vendored Rajdhani (OFL); app must work fully offline. |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ in Rivals.
 - **Dirty-lap flags** — the packet has no "lap invalidated" field, so LapScope infers
   it: ⏪ **rewind** (the lap clock ran backwards) and 💥 **contact** (a G-spike beyond
   what tires can generate). Rewound stretches are trimmed from the charts and map.
+- **You have the final say** — detection wrong on a recording? Right-click a contact
+  marker on the map to dismiss it, edit a lap's flags, or exclude junk laps from the
+  bests — all reversible (**Reset edits**), and kept across a **Reprocess**.
 - **Automatic event detection** — races, Rivals, sprints, drags, touge,
   cross-country, and **World Time Attack** are each detected and timed correctly, even
   though the game never labels them (it doesn't even count the last lap of a race).

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -15,6 +15,7 @@ from ..cars import CAR_NAMES
 from ..recorder.laps import (AIRBORNE_MIN_S, AIRBORNE_SLIP_MAX,
                              AIRBORNE_SUSP_MAX, IMPACT_ACCEL, LANDING_GRACE_S)
 from ..recorder.reprocess import reprocess_session
+from ..recorder.store import lap_anchor, lap_span
 from ..telemetry.packet import parse
 
 log = logging.getLogger("lapscope.api")
@@ -134,7 +135,9 @@ async def reprocess(session_id: int, request: Request):
     detection logic. async on purpose: the replay writes laps through the
     Store's event-loop connection — which also means it blocks the loop for
     the whole replay, so it must not run while ANY session is recording
-    (a long replay would freeze live telemetry and the dashboard mid-race)."""
+    (a long replay would freeze live telemetry and the dashboard mid-race).
+    Manual edits survive on purpose (they're user intent, keyed by frame time
+    - see store.py); DELETE /sessions/{id}/edits is the way to drop them."""
     store = request.app.state.store
     if store.get_session(session_id) is None:
         raise HTTPException(404, "session not found")
@@ -226,37 +229,133 @@ def session_laps(session_id: int, request: Request):
     if session is None:
         raise HTTPException(404, "session not found")
     laps = store.session_laps(session_id)
-    best = min((lap["lap_time"] for lap in laps if lap["lap_time"]), default=None)
+    # excluded laps (manual edit) stay listed but never score: no best, no gap
+    best = min((lap["lap_time"] for lap in laps
+                if lap["lap_time"] and not lap["excluded"]), default=None)
     for lap in laps:
-        lap["is_best"] = bool(lap["lap_time"]) and lap["lap_time"] == best
-        lap["gap_to_best"] = (lap["lap_time"] - best) if lap["lap_time"] and best else None
-    return {"session": _session_out(session), "laps": laps}
+        timed = bool(lap["lap_time"]) and not lap["excluded"]
+        lap["is_best"] = timed and lap["lap_time"] == best
+        lap["gap_to_best"] = (lap["lap_time"] - best) if timed and best else None
+    session = _session_out(session)
+    # drives the "Reset edits" affordance on the analysis page
+    session["edit_count"] = len(store.session_edits(session_id))
+    return {"session": session, "laps": laps}
 
 
-@router.get("/laps/{lap_id}/data")
-def lap_data(
-    lap_id: int,
-    request: Request,
-    channels: str = Query("speed_kmh,throttle,brake"),
-    max_points: int = Query(2000, ge=50, le=20000),
-):
+LAP_FLAGS = {"rewind", "contact", "cutoff"}
+
+
+class LapPatch(BaseModel):
+    flags: str | None = None
+    excluded: bool | None = None
+
+
+@router.patch("/laps/{lap_id}")
+def patch_lap(lap_id: int, body: LapPatch, request: Request):
+    """Manual lap curation, stored as read-time edits keyed by frame time so
+    a reprocess keeps them (see the edits table in store.py). flags: the full
+    CSV the lap should carry ("" = none); a value equal to what the recorder
+    detected removes the override instead, reverting the lap to auto.
+    excluded: drop/restore the lap from bests and session counts."""
     store = request.app.state.store
     lap = store.get_lap(lap_id)
     if lap is None:
         raise HTTPException(404, "lap not found")
+    t0, t1 = lap_span(lap)
+    if body.flags is not None:
+        tokens = {f.strip() for f in body.flags.split(",") if f.strip()}
+        if not tokens <= LAP_FLAGS:
+            raise HTTPException(400, f"flags must be from {sorted(LAP_FLAGS)}")
+        value = ",".join(sorted(tokens))  # same format the recorder writes
+        store.remove_edits(lap["session_id"], "flags", t0, t1)
+        if value != (lap["flags"] or ""):
+            store.add_edit(lap["session_id"], "flags", lap_anchor(lap), value)
+    if body.excluded is not None:
+        store.remove_edits(lap["session_id"], "exclude_lap", t0, t1)
+        if body.excluded:
+            store.add_edit(lap["session_id"], "exclude_lap", lap_anchor(lap))
+    return {"ok": True}
 
-    names = [c.strip() for c in channels.split(",") if c.strip()]
-    unknown = [n for n in names if n not in CHANNELS]
-    if unknown:
-        raise HTTPException(400, f"unknown channels: {unknown}; available: {sorted(CHANNELS)}")
 
-    rows = store.lap_frames(lap)
-    start_dist = lap["start_distance"] or 0.0
+class DismissBody(BaseModel):
+    t: float
 
-    # Rewind safety: when the in-game rewind scrubs DistanceTraveled backwards,
-    # drop the samples it rewound over so only the finally-driven pass remains
-    # (otherwise charts and the map draw the same stretch twice). This also
-    # cleans up reversing after a spin.
+
+@router.post("/laps/{lap_id}/dismiss_contact")
+def dismiss_contact(lap_id: int, body: DismissBody, request: Request):
+    """"Not a contact": dismiss the collision whose peak frame time is t
+    (from the collision list of /laps/{id}/data). The marker is tagged
+    dismissed at read time; when no real (non-landing, non-dismissed)
+    contact remains on the lap, its contact flag is lifted through a flags
+    override. Flags are only ever removed here, never added."""
+    store = request.app.state.store
+    lap = store.get_lap(lap_id)
+    if lap is None:
+        raise HTTPException(404, "lap not found")
+    _, collisions, _ = _scan_lap(store.lap_frames(lap), lap["start_distance"] or 0.0)
+    if not any(abs(c["t"] - body.t) <= DISMISS_MATCH_S for c in collisions):
+        raise HTTPException(404, "no contact marker at that time")
+    store.add_edit(lap["session_id"], "dismiss_contact", body.t)
+    edits = store.session_edits(lap["session_id"])
+    _apply_dismissals(collisions, edits)
+    remaining = sum(1 for c in collisions if not c["landing"] and not c["dismissed"])
+    # effective flags: an existing user override wins over the detected CSV
+    t0, t1 = lap_span(lap)
+    flags = lap["flags"] or ""
+    for e in edits:
+        if e["kind"] == "flags" and t0 <= e["anchor_t"] <= t1:
+            flags = e["value"] or ""
+    if remaining == 0 and "contact" in flags.split(","):
+        flags = ",".join(f for f in flags.split(",") if f and f != "contact")
+        store.remove_edits(lap["session_id"], "flags", t0, t1)
+        if flags != (lap["flags"] or ""):
+            store.add_edit(lap["session_id"], "flags", lap_anchor(lap), flags)
+    return {"ok": True, "remaining_contacts": remaining, "flags": flags or None}
+
+
+@router.delete("/sessions/{session_id}/edits")
+def reset_edits(session_id: int, request: Request):
+    """The escape hatch: drop every manual edit of the session (contact
+    dismissals, flag overrides, lap exclusions) so it shows exactly what the
+    recorder detected again."""
+    store = request.app.state.store
+    if store.get_session(session_id) is None:
+        raise HTTPException(404, "session not found")
+    return {"ok": True, "removed": store.clear_edits(session_id)}
+
+
+# dismissed-contact edits match a collision by its peak frame time within
+# this tolerance: retuning the detection constants can shift a burst's peak
+# by a frame or two across a reprocess, never further (bursts are grouped)
+DISMISS_MATCH_S = 0.5
+
+
+def _scan_lap(rows: list[tuple[float, bytes]], start_dist: float):
+    """One lap's kept trace + collision/jump events, from its raw frames.
+    Shared by lap_data and the contact-dismissal endpoint so both always see
+    the exact same events. Returns (kept, collisions, jumps).
+
+    Rewind safety: when the in-game rewind scrubs DistanceTraveled backwards,
+    drop the samples it rewound over so only the finally-driven pass remains
+    (otherwise charts and the map draw the same stretch twice). This also
+    cleans up reversing after a spin.
+
+    Collision points: ground-plane acceleration spikes past the contact
+    threshold (the same test the recorder uses for the per-lap "contact"
+    flag). A single impact spans several frames over the threshold, so group
+    consecutive over-threshold frames into one event and keep its peak. Run
+    on the full-resolution kept trace so a one-frame spike is never decimated
+    away. World coords are returned so the map projects them like any point;
+    the peak's frame time t is the handle a dismissal edit anchors to.
+    Spikes while airborne or right after touchdown are jump landings, not
+    contact (same classification as the recorder) - tagged, not dropped, so
+    the map can still show where a jump bottomed out.
+
+    Jump segments: the same airborne classifier also yields explicit flights
+    (every wheel unloaded for >= AIRBORNE_MIN_S). Each is returned as a
+    takeoff -> touchdown segment so the map can draw where the car left the
+    ground and where it came down; a landing-classified spike marks the
+    segment "hard" with its peak g."""
     kept: list[tuple[float, float, dict]] = []  # (t, distance, parsed frame)
     for t, raw in rows:
         p = parse(raw)
@@ -266,33 +365,19 @@ def lap_data(
                 kept.pop()
         kept.append((t, d, p))
 
-    # Collision points: ground-plane acceleration spikes past the contact
-    # threshold (the same test the recorder uses for the per-lap "contact"
-    # flag). A single impact spans several frames over the threshold, so group
-    # consecutive over-threshold frames into one event and keep its peak. Run
-    # on the full-resolution kept trace so a one-frame spike is never decimated
-    # away. World coords are returned so the map projects them like any point.
-    # Spikes while airborne or right after touchdown are jump landings, not
-    # contact (same classification as the recorder) - tagged, not dropped, so
-    # the map can still show where a jump bottomed out.
-    #
-    # Jump segments: the same airborne classifier also yields explicit flights
-    # (every wheel unloaded for >= AIRBORNE_MIN_S). Each is returned as a
-    # takeoff -> touchdown segment so the map can draw where the car left the
-    # ground and where it came down; a landing-classified spike marks the
-    # segment "hard" with its peak g.
     collisions: list[dict] = []
     jumps: list[dict] = []
-    peak: tuple | None = None  # (g, d, frame) of the current impact burst
+    peak: tuple | None = None  # (g, t, d, frame) of the current impact burst
     burst_landing = True       # all frames of the burst classified as landing
     air_since: float | None = None
     air_start: tuple | None = None  # (t, d, frame) of the first airborne frame
     grace_until = 0.0
 
     def emit(peak: tuple, landing: bool) -> None:
-        g0, d0, p0 = peak
+        g0, t0, d0, p0 = peak
         collisions.append({"x": round(p0["pos_x"], 2), "y": round(p0["pos_y"], 2),
                            "z": round(p0["pos_z"], 2), "dist": round(d0 - start_dist, 2),
+                           "t": round(t0, 3),
                            "g": round(g0 / 9.80665, 2), "landing": landing})
         if landing and jumps:
             jumps[-1]["hard"] = True
@@ -322,9 +407,9 @@ def lap_data(
         g = math.hypot(p["accel_x"], p["accel_z"])
         if g >= IMPACT_ACCEL:
             if peak is None:
-                peak, burst_landing = (g, d, p), True
+                peak, burst_landing = (g, t, d, p), True
             elif g > peak[0]:
-                peak = (g, d, p)
+                peak = (g, t, d, p)
             burst_landing = burst_landing and (flying or t < grace_until)
         elif peak is not None:
             emit(peak, burst_landing)
@@ -334,7 +419,41 @@ def lap_data(
     if peak is not None:  # impact ran to the last kept frame
         emit(peak, burst_landing)
 
+    return kept, collisions, jumps
+
+
+def _apply_dismissals(collisions: list[dict], edits: list[dict]) -> None:
+    """Tag the collisions the user dismissed ("not a contact"). Dismissed
+    markers are returned tagged rather than dropped: the count and the map
+    skip them, but the data stays inspectable."""
+    anchors = [e["anchor_t"] for e in edits if e["kind"] == "dismiss_contact"]
+    for c in collisions:
+        c["dismissed"] = any(abs(c["t"] - a) <= DISMISS_MATCH_S for a in anchors)
+
+
+@router.get("/laps/{lap_id}/data")
+def lap_data(
+    lap_id: int,
+    request: Request,
+    channels: str = Query("speed_kmh,throttle,brake"),
+    max_points: int = Query(2000, ge=50, le=20000),
+):
+    store = request.app.state.store
+    lap = store.get_lap(lap_id)
+    if lap is None:
+        raise HTTPException(404, "lap not found")
+
+    names = [c.strip() for c in channels.split(",") if c.strip()]
+    unknown = [n for n in names if n not in CHANNELS]
+    if unknown:
+        raise HTTPException(400, f"unknown channels: {unknown}; available: {sorted(CHANNELS)}")
+
+    rows = store.lap_frames(lap)
+    kept, collisions, jumps = _scan_lap(rows, lap["start_distance"] or 0.0)
+    _apply_dismissals(collisions, store.session_edits(lap["session_id"]))
+
     stride = max(1, len(kept) // max_points)
+    start_dist = lap["start_distance"] or 0.0
     dist: list[float] = []
     t_rel: list[float] = []
     out: dict[str, list[float]] = {n: [] for n in names}

--- a/app/recorder/store.py
+++ b/app/recorder/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import math
 import sqlite3
+import time
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -53,7 +54,24 @@ CREATE TABLE IF NOT EXISTS car_names (
     ordinal INTEGER PRIMARY KEY,
     name    TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS edits (
+    id         INTEGER PRIMARY KEY,
+    session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind       TEXT NOT NULL,
+    anchor_t   REAL NOT NULL,
+    value      TEXT,
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_edits_session ON edits(session_id);
 """
+
+# Manual session edits (analysis page), applied at read time - raw frames and
+# the recorder's lap rows are never rewritten. Keyed by frame timestamps, not
+# lap ids, so a reprocess (which deletes and recreates lap rows) keeps them:
+#   dismiss_contact  anchor_t = the collision burst's peak frame t
+#   flags            anchor_t inside a lap's [started_t, ended_t] span;
+#                    value = the full flags CSV ("" = no flags)
+#   exclude_lap      anchor_t inside a lap's span; lap drops out of bests/counts
 
 # added after v1; applied to existing databases on startup
 MIGRATIONS = (
@@ -77,6 +95,22 @@ FROM sessions s
 LEFT JOIN routes r ON r.id = s.route_id
 LEFT JOIN car_names cn ON cn.ordinal = s.car_ordinal
 """
+
+
+def lap_span(lap: dict) -> tuple[float, float]:
+    """A lap's frame-time span; an open lap (NULL ended_t - only ever the
+    last one) extends to infinity so an anchor inside it still matches."""
+    end = lap["ended_t"] if lap["ended_t"] is not None else float("1e18")
+    return lap["started_t"], end
+
+
+def lap_anchor(lap: dict) -> float:
+    """Frame-time anchor identifying a lap across reprocesses: the midpoint
+    of its span (started_t for an open lap). Midpoints avoid boundary ties
+    with adjacent laps and still land inside the corresponding lap after a
+    reprocess re-segments the session."""
+    end = lap["ended_t"] if lap["ended_t"] is not None else lap["started_t"]
+    return (lap["started_t"] + end) / 2
 
 
 class Store:
@@ -261,7 +295,12 @@ class Store:
                 " FROM sessions s"
                 " LEFT JOIN routes r ON r.id = s.route_id"
                 " LEFT JOIN car_names cn ON cn.ordinal = s.car_ordinal"
-                " LEFT JOIN laps l ON l.session_id = s.id"
+                # excluded laps (manual edit) don't count: same span-match as
+                # session_laps, in SQL
+                " LEFT JOIN laps l ON l.session_id = s.id AND NOT EXISTS"
+                "  (SELECT 1 FROM edits e WHERE e.session_id = l.session_id"
+                "   AND e.kind = 'exclude_lap' AND e.anchor_t >= l.started_t"
+                "   AND e.anchor_t <= COALESCE(l.ended_t, 1e18))"
                 " GROUP BY s.id ORDER BY s.started_at DESC"
             ).fetchall()
         return [dict(r) for r in rows]
@@ -340,11 +379,61 @@ class Store:
             conn.commit()
 
     def session_laps(self, session_id: int) -> list[dict]:
+        """Lap rows with manual edits applied at read time: `flags` is the
+        effective value (a 'flags' override wins over what the recorder
+        detected, which stays in `flags_auto`), `excluded` marks laps the
+        user dropped from bests/counts."""
         with self.reader() as conn:
             rows = conn.execute(
                 "SELECT * FROM laps WHERE session_id = ? ORDER BY started_t", (session_id,)
             ).fetchall()
+        laps = [dict(r) for r in rows]
+        edits = self.session_edits(session_id)
+        for lap in laps:
+            lap["flags_auto"] = lap["flags"]
+            lap["excluded"] = False
+            t0, t1 = lap_span(lap)
+            for e in edits:
+                if not t0 <= e["anchor_t"] <= t1:
+                    continue
+                if e["kind"] == "flags":
+                    lap["flags"] = e["value"] or None
+                elif e["kind"] == "exclude_lap":
+                    lap["excluded"] = True
+        return laps
+
+    def session_edits(self, session_id: int) -> list[dict]:
+        with self.reader() as conn:
+            rows = conn.execute(
+                "SELECT * FROM edits WHERE session_id = ? ORDER BY created_at",
+                (session_id,)).fetchall()
         return [dict(r) for r in rows]
+
+    def add_edit(self, session_id: int, kind: str, anchor_t: float,
+                 value: str | None = None) -> None:
+        with self.reader() as conn:
+            conn.execute(
+                "INSERT INTO edits (session_id, kind, anchor_t, value, created_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (session_id, kind, anchor_t, value, time.time()))
+            conn.commit()
+
+    def remove_edits(self, session_id: int, kind: str, t0: float, t1: float) -> int:
+        """Drop edits of one kind anchored inside [t0, t1] (a lap's span)."""
+        with self.reader() as conn:
+            cur = conn.execute(
+                "DELETE FROM edits WHERE session_id = ? AND kind = ?"
+                " AND anchor_t >= ? AND anchor_t <= ?",
+                (session_id, kind, t0, t1))
+            conn.commit()
+            return cur.rowcount
+
+    def clear_edits(self, session_id: int) -> int:
+        """The "Reset edits" escape hatch: drop every manual edit at once."""
+        with self.reader() as conn:
+            cur = conn.execute("DELETE FROM edits WHERE session_id = ?", (session_id,))
+            conn.commit()
+            return cur.rowcount
 
     def get_lap(self, lap_id: int) -> dict | None:
         with self.reader() as conn:

--- a/app/static/analysis.html
+++ b/app/static/analysis.html
@@ -53,14 +53,15 @@
       <button id="btn-rename">Rename</button>
       <button id="btn-route">Name route</button>
       <button id="btn-car">Name car</button>
-      <button id="btn-reprocess" title="Re-run lap detection over the stored telemetry">Reprocess</button>
+      <button id="btn-reprocess" title="Re-run lap detection over the stored telemetry (manual edits are kept)">Reprocess</button>
+      <button id="btn-reset-edits" style="display:none" title="Remove every manual edit — dismissed contacts, flag overrides, excluded laps">Reset edits</button>
       <button id="btn-delete" class="danger">Delete</button>
     </div>
     <div class="car-line" id="header-car"></div>
     <section class="panel">
       <h2>Laps</h2>
       <table class="laps">
-        <thead><tr><th>Compare</th><th>Lap</th><th>Time</th><th>Gap</th><th></th></tr></thead>
+        <thead><tr><th>Compare</th><th>Lap</th><th>Time</th><th>Gap</th><th></th><th></th></tr></thead>
         <tbody id="lap-rows"></tbody>
       </table>
     </section>
@@ -82,7 +83,7 @@
             <span id="legend-scale"></span>
             <span><span class="swatch" style="background:#5b6675"></span> lap B</span>
             <span><span class="swatch" style="background:#34d399"></span> start</span>
-            <span title="contact spike (wall / obstacle)"><span style="color:#ef4444">✦</span> contact</span>
+            <span title="contact spike (wall / obstacle) — right-click one to dismiss a wrong detection"><span style="color:#ef4444">✦</span> contact (right-click to dismiss)</span>
             <span title="jump: takeoff ○ to touchdown ▸ — a ring marks a hard landing"><span style="color:#f59e0b">○⇢</span> jump</span>
             <span>⌖ hover a chart to mark that spot · drag to zoom + highlight this span</span>
             <span id="map-hint" style="display:none">↔ drag the map to rotate</span>

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -538,6 +538,18 @@ main.grid .lap-grid { margin-bottom: auto; }
   box-shadow: 0 0 0 3px rgba(0, 212, 255, 0.12);
 }
 
+/* lap flag editor (analysis page): checkbox per dirty-lap marker */
+.flag-editor { margin: 0 0 12px; }
+.flag-editor label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 2px;
+  cursor: pointer;
+}
+.flag-editor input[type="checkbox"] { accent-color: var(--accent); }
+.modal-hint { color: var(--muted); font-size: 0.8rem; margin: 8px 0 0; }
+
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .modal-actions button {
   padding: 7px 16px;
@@ -795,6 +807,19 @@ table.laps th {
 }
 table.laps tr { border-bottom: 1px solid var(--panel-edge-soft); }
 table.laps tr.best td { color: var(--good); }
+/* manually excluded laps stay listed but visibly out of the running */
+table.laps tr.excluded td { color: var(--muted); opacity: 0.55; }
+table.laps tr.excluded .lap-time { text-decoration: line-through; }
+table.laps .lap-actions { text-align: right; white-space: nowrap; }
+table.laps .lap-act {
+  padding: 1px 7px;
+  font-size: 0.8rem;
+  background: transparent;
+  border-color: transparent;
+  opacity: 0.35;
+}
+table.laps tr:hover .lap-act { opacity: 1; }
+table.laps .lap-act:hover { border-color: var(--accent); background: var(--panel-lo); }
 table.laps .pick {
   display: inline-block;
   width: 26px;

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -114,6 +114,8 @@ async function selectSession(id) {
   $("#btn-route").onclick = () => renameRoute(s);
   $("#btn-car").onclick = () => renameCar(s);
   $("#btn-reprocess").onclick = () => reprocessSession(s);
+  $("#btn-reset-edits").style.display = s.edit_count ? "" : "none";
+  $("#btn-reset-edits").onclick = () => resetEdits(s);
   $("#btn-delete").onclick = () => deleteSession(s);
   $("#color-mode").value = state.colorMode;
   $("#color-mode").onchange = (e) => {
@@ -134,6 +136,7 @@ async function selectSession(id) {
   }
   $("#map-hint").style.display = state.mapMode === "3d" ? "" : "none";
   bindMapDrag($("#trackmap"));
+  bindMapContext($("#trackmap"));
 
   renderLapRows();
   loadSessions();
@@ -150,17 +153,104 @@ function renderLapRows() {
   for (const l of state.laps) {
     const tr = document.createElement("tr");
     if (l.is_best) tr.className = "best";
+    if (l.excluded) tr.className = "excluded";
+    // an override never changes the icons' meaning, just their source
+    const edited = (l.flags || "") !== (l.flags_auto || "");
     tr.innerHTML = `
       <td><span class="pick ${state.lapA === l.id ? "a" : ""}" data-slot="a">A</span>
           <span class="pick ${state.lapB === l.id ? "b" : ""}" data-slot="b">B</span></td>
       <td>${l.lap_number + 1}</td>
-      <td>${fmtLap(l.lap_time)}</td>
+      <td class="lap-time">${fmtLap(l.lap_time)}</td>
       <td>${l.gap_to_best != null && l.gap_to_best > 0 ? "+" + l.gap_to_best.toFixed(3) : (l.is_best ? "best" : "")}</td>
-      <td style="color:var(--muted)">${flagIcons(l.flags)}${l.lap_time ? "" : " incomplete"}</td>`;
+      <td style="color:var(--muted)">${flagIcons(l.flags)}${edited ? `<span class="lap-flag" title="flags edited by you — ✎ to change, Reset edits to undo">✎</span>` : ""}${l.lap_time ? "" : " incomplete"}${l.excluded ? " excluded" : ""}</td>
+      <td class="lap-actions">
+        <button class="lap-act act-flags" title="Edit this lap's flags">✎</button>
+        <button class="lap-act act-exclude" title="${l.excluded ? "Restore the lap into bests and counts" : "Exclude the lap from bests and counts"}">${l.excluded ? "↩" : "🗑"}</button>
+      </td>`;
     for (const pick of tr.querySelectorAll(".pick"))
       pick.onclick = () => pickLap(l.id, pick.dataset.slot);
+    $(".act-flags", tr).onclick = () => editLapFlags(l);
+    $(".act-exclude", tr).onclick = () => toggleLapExcluded(l);
     tbody.appendChild(tr);
   }
+}
+
+/* Re-fetch the session's laps + the picked laps' data after a manual edit,
+   keeping the A/B selection (unlike selectSession, which resets it). */
+async function reloadSession() {
+  const payload = await (await fetch(`/api/sessions/${state.sessionId}/laps`)).json();
+  state.laps = payload.laps;
+  const reset = $("#btn-reset-edits");
+  if (reset) reset.style.display = payload.session.edit_count ? "" : "none";
+  for (const slot of ["a", "b"]) {
+    const key = slot === "a" ? "lapA" : "lapB";
+    const dataKey = slot === "a" ? "dataA" : "dataB";
+    if (state[key] == null) continue;
+    const res = await fetch(
+      `/api/laps/${state[key]}/data?channels=${LAP_CHANNELS}&max_points=1500`);
+    if (res.ok) state[dataKey] = await res.json();
+  }
+  renderLapRows();
+  drawMap();
+  drawCharts();
+  loadSessions();  // lap counts / best on the session cards may have moved
+}
+
+const lapPatch = (lapId, body) => fetch(`/api/laps/${lapId}`, {
+  method: "PATCH",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+/* checkbox editor over the recorder's dirty-lap markers; stored as a
+   read-time override, so Reprocess keeps it and Reset edits undoes it */
+async function editLapFlags(lap) {
+  const extra = document.createElement("div");
+  extra.className = "flag-editor";
+  const current = new Set((lap.flags || "").split(",").filter(Boolean));
+  const boxes = {};
+  for (const [flag, [icon, desc]] of Object.entries(FLAG_META)) {
+    const label = document.createElement("label");
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = current.has(flag);
+    boxes[flag] = cb;
+    label.append(cb, ` ${icon} ${flag}`);
+    label.title = desc;
+    extra.appendChild(label);
+  }
+  const detected = (lap.flags_auto || "").split(",").filter(Boolean)
+    .map((f) => (FLAG_META[f] ? `${FLAG_META[f][0]} ${f}` : f)).join(", ") || "none";
+  const hint = document.createElement("p");
+  hint.className = "modal-hint";
+  hint.textContent = `Detected by the recorder: ${detected}. Matching it removes your override.`;
+  extra.appendChild(hint);
+  const ok = await showModal({
+    title: `Lap ${lap.lap_number + 1} — flags`,
+    message: "Detection is heuristic; correct this lap's markers here. Reprocess keeps your choice.",
+    extra, okText: "Save",
+  });
+  if (!ok) return;
+  const flags = Object.keys(boxes).filter((f) => boxes[f].checked).join(",");
+  await lapPatch(lap.id, { flags });
+  reloadSession();
+}
+
+/* excluded laps stay listed (grayed) but drop out of best/gap and the
+   session card's lap count - reversible, so no confirm */
+async function toggleLapExcluded(lap) {
+  await lapPatch(lap.id, { excluded: !lap.excluded });
+  reloadSession();
+}
+
+async function resetEdits(session) {
+  const sure = await uiConfirm("Reset edits",
+    "Remove every manual edit on this session — dismissed contact markers, lap flag "
+    + "overrides, and excluded laps — and show exactly what the recorder detected?",
+    { okText: "Reset", danger: true });
+  if (!sure) return;
+  await fetch(`/api/sessions/${session.id}/edits`, { method: "DELETE" });
+  reloadSession();
 }
 
 async function pickLap(lapId, slot) {
@@ -280,7 +370,8 @@ async function reprocessSession(session) {
   const sure = await uiConfirm("Reprocess session",
     "Re-run lap detection over this session's stored telemetry? The lap list "
     + "is rebuilt with the current detection logic (recovers laps from events "
-    + "recorded before a fix, e.g. World Time Attack).",
+    + "recorded before a fix, e.g. World Time Attack). Manual edits — dismissed "
+    + "contacts, flag overrides, excluded laps — are kept.",
     { okText: "Reprocess" });
   if (!sure) return;
   const res = await fetch(`/api/sessions/${session.id}/reprocess`, { method: "POST" });
@@ -360,6 +451,45 @@ function drawMapMarker() {
   ctx.restore();
 }
 
+/* screen-space contact markers of the last drawMap, for right-click hit
+   testing (dismiss flow); refilled on every draw */
+const hitMarkers = [];
+const HIT_RADIUS_PX = 12;
+
+function nearestMarker(x, y) {
+  let best = null, bestD = HIT_RADIUS_PX;
+  for (const m of hitMarkers) {
+    const d = Math.hypot(m.x - x, m.y - y);
+    if (d <= bestD) { best = m; bestD = d; }
+  }
+  return best;
+}
+
+/* right-click a contact spark -> "not a contact": the marker stops counting
+   and the lap's 💥 flag lifts once no real contact remains (see issue #26) */
+function bindMapContext(canvas) {
+  canvas.addEventListener("contextmenu", async (e) => {
+    const hit = nearestMarker(e.offsetX, e.offsetY);
+    if (!hit) return;  // not on a marker: leave the browser menu alone
+    e.preventDefault();
+    const ok = await uiConfirm("Not a contact?",
+      "Dismiss this contact marker? It stops counting toward Contacts (and the lap's "
+      + "💥 flag lifts once no real contact remains). Reset edits brings it back.",
+      { okText: "Dismiss" });
+    if (!ok) return;
+    const res = await fetch(`/api/laps/${hit.lapId}/dismiss_contact`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ t: hit.t }),
+    });
+    if (!res.ok) {
+      await uiAlert("Dismiss failed", (await res.json()).detail || "failed");
+      return;
+    }
+    reloadSession();
+  });
+}
+
 function bindMapDrag(canvas) {
   canvas.addEventListener("pointerdown", (e) => {
     if (state.mapMode !== "3d") return;
@@ -391,6 +521,7 @@ function drawMap() {
   ctx.clearRect(0, 0, cssW, cssH);
 
   mapCursor.proj = null; // stale until this draw completes
+  hitMarkers.length = 0; // refilled by drawHits below
 
   const A = state.dataA, B = state.dataB;
   const three = state.mapMode === "3d";
@@ -611,8 +742,8 @@ function drawMap() {
 
     const side = $("#map-side");
     const lapMeta = state.laps.find((l) => l.id === state.lapA);
-    // landings (spikes on jump touchdowns) are shown but not counted as contact
-    const contacts = (A.collisions || []).filter((h) => !h.landing).length;
+    // landings (jump touchdowns) and user-dismissed spikes don't count
+    const contacts = (A.collisions || []).filter((h) => !h.landing && !h.dismissed).length;
     const jumps = A.jumps || [];
     const hard = jumps.filter((j) => j.hard).length;
     side.innerHTML = `<div class="lap-grid" style="text-align:left">
@@ -642,8 +773,10 @@ function drawMap() {
   const drawHits = (d, fill, r) => {
     if (!d || !d.collisions) return;
     for (const h of d.collisions) {
-      if (h.landing) continue;  // drawn as its jump's touchdown, not a spark
+      if (h.landing) continue;   // drawn as its jump's touchdown, not a spark
+      if (h.dismissed) continue; // user said "not a contact"
       const [X, Y] = P(h.x, h.y ?? 0, h.z, false);
+      hitMarkers.push({ x: X, y: Y, lapId: d.lap.id, t: h.t });
       ctx.save();
       ctx.strokeStyle = "#fff";
       ctx.lineWidth = 1.5;

--- a/docs/wiki/Event-Detection.md
+++ b/docs/wiki/Event-Detection.md
@@ -162,6 +162,22 @@ tracked in [issue #27](https://github.com/darcane/LapScope/issues/27).
 Flags reset when a lap re-anchors (a WTA launch, a mid-session lap-timer
 start), so pre-launch junk frames never dirty lap 1.
 
+## When detection is wrong: edit the recording
+
+Every rule on this page is an inference, and inferences miss. Instead of
+waiting for a tuning fix, curate the recording yourself on the analysis page:
+
+- **Right-click a contact spark on the track map → dismiss** ("not a
+  contact"). The marker stops counting, and the lap's 💥 flag lifts once no
+  real contact remains on it.
+- **✎ in the lap table** edits a lap's ⏪/💥/🏁 flags directly.
+- **🗑 in the lap table** excludes a junk lap (an out-lap, a wrong detection)
+  from the best-lap stats and session counts; ↩ restores it.
+
+Edits are stored as overrides next to the recording — the raw telemetry is
+never touched — and they survive a **Reprocess** (they're your call, not the
+detector's). **Reset edits** in the session header undoes all of them at once.
+
 ## Routes
 
 The game never sends route names, so circuits are **fingerprinted**: same
@@ -205,7 +221,8 @@ Recordings are lossless raw packets, so the **Reprocess** button replays a
 session's stored frames through a fresh tracker — every detection improvement
 on this page can be applied to recordings made before it existed. (Refused
 with a 409 while any recording is in progress, so a long replay can't freeze
-live telemetry.)
+live telemetry.) Manual edits — dismissed contacts, flag overrides, excluded
+laps — are kept across a reprocess; **Reset edits** is the way to drop them.
 
 ## Known accepted trade-offs
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from harness import completed_laps, run, sessions
+from harness import completed_laps, flags_of, run, sessions
 from app.recorder.store import Store
 
 
@@ -273,3 +273,172 @@ def test_car_override_set_and_clear(tmp_path):
     out = car_name(999999, req)
     store.close()
     assert out["known"] is False and out["name"] == "Car #999999"
+
+
+# ------------------------- manual session edits (issue #26) -------------------------
+# Stored in the `edits` table keyed by frame time, applied at read time; raw
+# frames and the recorder's lap rows are never rewritten.
+
+
+def _dirty_store(tmp_path):
+    """3-lap race with a wall contact on lap 2 and a rewind on lap 3 (the
+    --dirty scenario asserted in test_scenarios)."""
+    def scenario(sim):
+        sim.event(180, "dirty", dirty=True)
+        sim.race_off()
+
+    return run(scenario, tmp_path)
+
+
+def test_dismiss_contact_clears_marker_and_lifts_the_flag(tmp_path):
+    """Right-click "not a contact": the marker comes back tagged dismissed
+    from /laps/{id}/data (not dropped - the data stays inspectable), and once
+    no real contact remains the lap's contact flag is lifted via a flags
+    override while flags_auto keeps what the recorder detected."""
+    from app.api.routes import DismissBody, dismiss_contact, lap_data, session_laps
+
+    store = _dirty_store(tmp_path)
+    sid = sessions(store)[0]["id"]
+    req = _request_for(store)
+    lap = next(lap for lap in completed_laps(store, sid) if "contact" in flags_of(lap))
+
+    data = lap_data(lap["id"], req, "speed_kmh", 500)
+    hits = [c for c in data["collisions"] if not c["landing"]]
+    assert hits and all(not c["dismissed"] for c in data["collisions"])
+
+    for c in hits:
+        out = dismiss_contact(lap["id"], DismissBody(t=c["t"]), req)
+    assert out["remaining_contacts"] == 0
+    assert not out["flags"] or "contact" not in out["flags"]
+
+    data = lap_data(lap["id"], req, "speed_kmh", 500)
+    assert all(c["dismissed"] for c in data["collisions"] if not c["landing"])
+
+    row = next(r for r in session_laps(sid, req)["laps"] if r["id"] == lap["id"])
+    assert "contact" not in (row["flags"] or "")
+    assert "contact" in row["flags_auto"]
+
+
+def test_dismiss_contact_rejects_a_time_with_no_marker(tmp_path):
+    """A dismissal must anchor to a real collision peak: a t that matches
+    nothing is a 404, not a silently stored dangling edit."""
+    from app.api.routes import DismissBody, dismiss_contact
+
+    store = _dirty_store(tmp_path)
+    sid = sessions(store)[0]["id"]
+    req = _request_for(store)
+    lap = next(lap for lap in completed_laps(store, sid) if "contact" in flags_of(lap))
+
+    with pytest.raises(HTTPException) as exc:
+        dismiss_contact(lap["id"], DismissBody(t=-999.0), req)
+    assert exc.value.status_code == 404
+    assert store.session_edits(sid) == []
+    assert "contact" in flags_of(store.session_laps(sid)[lap["lap_number"]])
+
+
+def test_lap_flags_override_set_revert_and_validate(tmp_path):
+    """PATCH /laps/{id} flags: "" clears every marker (effective flags None,
+    detected CSV preserved in flags_auto); writing back exactly the detected
+    value removes the override instead of storing a no-op edit; unknown
+    tokens are a 400."""
+    from app.api.routes import LapPatch, patch_lap
+
+    store = _dirty_store(tmp_path)
+    sid = sessions(store)[0]["id"]
+    req = _request_for(store)
+    lap = next(lap for lap in completed_laps(store, sid) if "rewind" in flags_of(lap))
+
+    patch_lap(lap["id"], LapPatch(flags=""), req)
+    row = next(r for r in store.session_laps(sid) if r["id"] == lap["id"])
+    assert row["flags"] is None and row["flags_auto"] == flags_of(lap)
+
+    patch_lap(lap["id"], LapPatch(flags=flags_of(lap)), req)  # = detected: revert
+    assert store.session_edits(sid) == []
+    row = next(r for r in store.session_laps(sid) if r["id"] == lap["id"])
+    assert row["flags"] == flags_of(lap)
+
+    with pytest.raises(HTTPException) as exc:
+        patch_lap(lap["id"], LapPatch(flags="rewind,banana"), req)
+    assert exc.value.status_code == 400
+
+
+def test_exclude_lap_recomputes_bests_and_counts(tmp_path):
+    """Excluding the best lap: it stays listed (excluded=true, never is_best,
+    no gap) while the next-fastest becomes the best, and the session list's
+    lap_count / best_lap aggregates drop it too. Restore brings it all back."""
+    from app.api.routes import LapPatch, patch_lap, session_laps
+
+    def scenario(sim):
+        sim.event(180, "race")
+        sim.race_off()
+
+    store = run(scenario, tmp_path)
+    sid = sessions(store)[0]["id"]
+    req = _request_for(store)
+    before = session_laps(sid, req)
+    assert before["session"]["edit_count"] == 0
+    best = next(lap for lap in before["laps"] if lap["is_best"])
+    n_timed = sum(1 for lap in before["laps"] if lap["lap_time"])
+    assert n_timed >= 2
+
+    patch_lap(best["id"], LapPatch(excluded=True), req)
+    after = session_laps(sid, req)
+    assert after["session"]["edit_count"] == 1
+    row = next(r for r in after["laps"] if r["id"] == best["id"])
+    assert row["excluded"] and not row["is_best"] and row["gap_to_best"] is None
+    new_best = next(r for r in after["laps"] if r["is_best"])
+    assert new_best["id"] != best["id"]
+    listed = sessions(store)[0]
+    assert listed["lap_count"] == n_timed - 1
+    assert listed["best_lap"] == new_best["lap_time"]
+
+    patch_lap(best["id"], LapPatch(excluded=False), req)
+    assert sessions(store)[0]["lap_count"] == n_timed
+    restored = next(r for r in session_laps(sid, req)["laps"] if r["id"] == best["id"])
+    assert restored["is_best"] and not restored["excluded"]
+
+
+def test_edits_survive_reprocess_and_reset_reverts(tmp_path):
+    """The point of time-keyed edits: reprocess deletes and recreates every
+    lap row, yet dismissals, flag overrides and exclusions re-apply to the
+    rebuilt laps. DELETE /sessions/{id}/edits is the explicit way back to
+    exactly what the recorder detected."""
+    from app.api.routes import (DismissBody, LapPatch, dismiss_contact, lap_data,
+                                patch_lap, reset_edits)
+    from app.recorder.reprocess import reprocess_session
+
+    store = _dirty_store(tmp_path)
+    sid = sessions(store)[0]["id"]
+    req = _request_for(store)
+    laps = completed_laps(store, sid)
+    contact_lap = next(lap for lap in laps if "contact" in flags_of(lap))
+    rewind_lap = next(lap for lap in laps if "rewind" in flags_of(lap))
+    clean_lap = laps[0]
+
+    data = lap_data(contact_lap["id"], req, "speed_kmh", 500)
+    for c in data["collisions"]:
+        if not c["landing"]:
+            dismiss_contact(contact_lap["id"], DismissBody(t=c["t"]), req)
+    patch_lap(rewind_lap["id"], LapPatch(flags=""), req)
+    patch_lap(clean_lap["id"], LapPatch(excluded=True), req)
+
+    store2 = Store(store.db_path)  # replay writes via the event-loop connection
+    reprocess_session(store2, sid)
+    store2.close()
+
+    rows = {r["lap_number"]: r for r in store.session_laps(sid)}
+    redone = rows[contact_lap["lap_number"]]
+    # flags_auto == the replay re-detected the contact on the rebuilt row;
+    # the override (keyed by time, not by the recycled lap id) still lifts it
+    assert "contact" in redone["flags_auto"] and "contact" not in (redone["flags"] or "")
+    assert rows[rewind_lap["lap_number"]]["flags"] is None
+    assert rows[clean_lap["lap_number"]]["excluded"]
+    data = lap_data(redone["id"], req, "speed_kmh", 500)
+    assert all(c["dismissed"] for c in data["collisions"] if not c["landing"])
+
+    out = reset_edits(sid, req)
+    assert out["removed"] >= 3
+    for row in store.session_laps(sid):
+        assert row["flags"] == row["flags_auto"] and not row["excluded"]
+    data = lap_data(redone["id"], req, "speed_kmh", 500)
+    assert not any(c["dismissed"] for c in data["collisions"])


### PR DESCRIPTION
## Summary

Event detection is heuristic and sometimes wrong on real data: a contact 💥 that wasn't a hit, a lap that should carry different flags, junk laps polluting the bests. Until now the only remedies were the all-or-nothing contact-layer toggle and `Reprocess`. This adds per-recording curation from the analysis page. Closes #26.

- **Dismiss contact markers** — right-click a ✦ spark on the track map → "not a contact". The marker stops counting toward Contacts, and the lap's 💥 flag lifts automatically once no real (non-landing, non-dismissed) contact remains. Jump landings were never dismissible to begin with — they aren't contact.
- **Re-tag laps** — a ✎ button per lap row opens a checkbox editor for ⏪ rewind / 💥 contact / 🏁 cutoff, with a "detected by the recorder" hint; saving exactly the detected value removes the override instead of storing a no-op edit.
- **Exclude/restore laps** — 🗑/↩ per row. Excluded laps stay listed (grayed, struck time) but drop out of `is_best`/`gap_to_best` and the session list's `lap_count`/`best_lap` aggregates.
- **Reset edits** — header button (visible only when edits exist) drops every manual edit of the session at once.

Scope note: the issue's "cut a time range" trim variant is deliberately left out — per-lap exclusion covers the junk cases since everything user-visible is lap-scoped.

### Design (the part worth reviewing)

Per the constraints in AGENTS.md and the issue: **raw packets are never modified, and the recorder's `laps.flags` are never rewritten.** All edits are read-time overrides in a new `edits` table, keyed by **frame timestamps — never lap ids**:

- `dismiss_contact` anchors to the collision burst's peak frame time (matched ±0.5 s, `DISMISS_MATCH_S`);
- `flags` / `exclude_lap` anchor to the lap-span midpoint and apply to whichever lap contains it.

This matters because `reprocess` deletes and recreates lap rows **under recycled SQLite rowids** — id-keyed edits would silently attach to the wrong laps. Time-keyed edits re-apply to the rebuilt laps by design (they're user intent); `DELETE /api/sessions/{id}/edits` is the explicit way back to pure detection.

API surface: `PATCH /api/laps/{id}` (`flags`, `excluded`), `POST /api/laps/{id}/dismiss_contact`, `DELETE /api/sessions/{id}/edits`. `/laps/{id}/data` collisions gain `t` (the dismissal handle) + `dismissed`; `/sessions/{id}/laps` gains per-lap `flags_auto`/`excluded` and a session `edit_count`. The collision/jump scan was factored out of `lap_data` into `_scan_lap()` so the dismiss endpoint sees identical events.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Event-detection change (recorder / `laps.py`)
- [ ] Docs only
- [ ] Refactor / chore

## How was it tested?

- 5 new harness-driven tests in `tests/test_api.py` (no container): dismiss clears the marker and lifts the flag; a t matching no collision 404s without storing a dangling edit; flags override set/revert-to-detected/400; excluding the best lap recomputes bests and the session-list aggregates; and the critical one — dismissal + override + exclusion all survive `reprocess_session` and revert on reset. Full suite: **60 passed**; `ruff check .` and the packet self-test pass.
- Browser walkthrough against a seeded `--dirty --jumps` session (wall hit on lap 2, hard landings on every lap): dismissal dropped Contacts 1→0 while landings stayed un-dismissable, the flags editor cleared a ⏪, excluding the best lap promoted the next one and updated the session card, Reset edits restored everything to detected.

## Checklist

- [x] Branched off `main` as `feat/…` or `fix/…`.
- [x] `ruff check .` passes.
- [x] `python app/telemetry/packet.py` (packet self-test) passes.
- [x] `pytest -q` passes.
- [x] Docs updated where relevant (AGENTS.md for detection changes,
      ARCHITECTURE.md for structural/schema/API changes, README.md for
      user-visible features).
- [ ] For a new detection scenario: added a `tools/simulator.py` flag **and** a
      matching assertion in `tests/test_scenarios.py`. — n/a: no detection change; the existing `--dirty` scenario stages the tests
- [x] Cross-file invariants kept in sync (see ARCHITECTURE.md "Cross-file
      invariants").

🤖 Generated with [Claude Code](https://claude.com/claude-code)