### PR TITLE
fix: analysis UI round-up — map zoom, overlay polish, pinned cursor, car 3304

### DIFF
--- a/app/car_ordinals.json
+++ b/app/car_ordinals.json
@@ -408,6 +408,7 @@
     "1993 Porsche 962 C RS": "3288",
     "2019 Lamborghini Aventador SVJ": "3289",
     "1993 Jaguar XJ220 S": "3293",
+    "1990 Alfa Romeo SE 048SP": "3304",
     "2019 Nissan 370Z Nismo": "3307",
     "FER_FXXKEvo_18": "3311",
     "2019 Ferrari Monza SP2": "3312",

--- a/app/static/analysis.html
+++ b/app/static/analysis.html
@@ -93,7 +93,7 @@
             <span><span class="swatch" style="background:#34d399"></span> start</span>
             <span title="contact spike (wall / obstacle) — right-click one to dismiss a wrong detection"><span style="color:#ef4444">✦</span> contact (right-click to dismiss)</span>
             <span title="jump: takeoff ○ to touchdown ▸ — a ring marks a hard landing"><span style="color:#f59e0b">○⇢</span> jump</span>
-            <span>⌖ hover a chart to mark that spot · drag to zoom + highlight this span</span>
+            <span>⌖ hover a chart to mark that spot · click to pin it · drag to zoom + highlight this span</span>
             <span id="map-hint" style="display:none">↔ drag the map to rotate</span>
           </div>
         </div>
@@ -107,7 +107,9 @@
     <section class="panel" id="raw-section" style="display:none">
       <h2>Raw data at cursor <span id="raw-pos" style="text-transform:none"></span></h2>
       <p class="raw-hint">Hover a comparison chart — every packet channel at that spot, per picked lap,
-        in game-native units. Values stay at the last hovered position.</p>
+        in game-native units. Click a chart to pin a spot: values return to it whenever the
+        cursor leaves the charts (click it again, or double-click, to unpin). Without a pin,
+        values stay at the last hovered position.</p>
       <div class="raw-table" id="raw-table"></div>
     </section>
   </div>

--- a/app/static/analysis.html
+++ b/app/static/analysis.html
@@ -82,7 +82,7 @@
             <span class="seg" id="map-mode">
               <button data-mode="2d">2D</button><button data-mode="3d">3D</button>
             </span>
-            <span>Color:
+            <span id="color-wrap">Color:
               <select id="color-mode">
                 <option value="speed">speed</option>
                 <option value="slip">tire slip</option>

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -901,7 +901,17 @@ table.laps .pick.on { font-weight: 600; }
   font-size: 0.9rem;
 }
 .tray-chip button:hover { color: var(--text); }
-.tray-warn { color: var(--warn); font-size: 0.8rem; }
+/* cross-route overlay: loud enough to not be skimmed past (a modal fires
+   once too, but this badge is what stays on screen) */
+.tray-warn {
+  color: var(--warn);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 3px 10px;
+  border: 1px solid rgba(255, 190, 61, 0.5);
+  background: rgba(255, 190, 61, 0.12);
+  border-radius: 6px;
+}
 .tray-clear { margin-left: auto; }
 
 .map-row { display: grid; grid-template-columns: 1fr 320px; gap: 12px; }

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -405,6 +405,7 @@ function renderPicks() {
     lastRefId = ref ? ref.lapId : null;
     state.zoomRange = null;
     mapCursor.idx = null;
+    mapCursor.pin = null;  // the pin is an index into the old reference's arrays
   }
   renderLapRows();
   renderTray();
@@ -618,14 +619,26 @@ function resetMapView() {
 
 /* chart cursor -> map marker: drawMap caches its finished frame plus the
    world->canvas projection, so hovering a chart only blits the cache and
-   paints a dot where lap A was at that track position */
-const mapCursor = { idx: null, proj: null, snap: null, dpr: 1 };
+   paints a dot where lap A was at that track position. pin = a clicked-in
+   position (same index space): the raw table and the map marker fall back to
+   it whenever the cursor is off the charts; without one, the old behavior
+   (values freeze at the last hovered spot) still applies. */
+const mapCursor = { idx: null, pin: null, proj: null, snap: null, dpr: 1 };
 
 function setMapCursor(idx) {
   if (idx === mapCursor.idx) return;
   mapCursor.idx = idx;
   drawMapMarker();
-  updateRawTable(idx);
+  updateRawTable(idx ?? mapCursor.pin);
+}
+
+/* chart click: pin the hovered spot (click it again to unpin) */
+function togglePin(idx) {
+  if (idx == null) return;
+  mapCursor.pin = mapCursor.pin === idx ? null : idx;
+  drawMapMarker();
+  updateRawTable(mapCursor.idx ?? mapCursor.pin);
+  for (const c of state.charts) c.redraw(); // pin line on every chart
 }
 
 function lowerBound(xs, x) {
@@ -646,31 +659,36 @@ function drawMapMarker() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.drawImage(mapCursor.snap, 0, 0);
   ctx.setTransform(mapCursor.dpr, 0, 0, mapCursor.dpr, 0, 0);
-  if (mapCursor.idx == null || !ref) return;
-  // the cursor index lives on the reference lap's arrays; every other lap is
-  // marked at the same track position (its own lower bound on dist), so the
-  // dots' spread IS the racing-line difference at that spot
-  const ri = Math.min(mapCursor.idx, ref.data.channels.pos_x.length - 1);
-  const dist = ref.data.dist[ri];
-  const dot = (p, i, r) => {
-    const c = p.data.channels;
-    const j = Math.min(i, c.pos_x.length - 1);
-    const [x, y] = mapCursor.proj(c.pos_x[j], c.pos_y ? c.pos_y[j] : 0, c.pos_z[j], false);
-    ctx.save();
-    ctx.shadowColor = p.color;
-    ctx.shadowBlur = 10;
-    ctx.fillStyle = p.color;
-    ctx.strokeStyle = "#fff";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-    ctx.restore();
+  if (!ref) return;
+  // an index lives on the reference lap's arrays; every other lap is marked
+  // at the same track position (its own lower bound on dist), so the dots'
+  // spread IS the racing-line difference at that spot. filled = live hover,
+  // hollow ring = the pinned point (both when hovering the pinned spot).
+  const markAt = (idx, filled) => {
+    const ri = Math.min(idx, ref.data.channels.pos_x.length - 1);
+    const dist = ref.data.dist[ri];
+    const dot = (p, i, r) => {
+      const c = p.data.channels;
+      const j = Math.min(i, c.pos_x.length - 1);
+      const [x, y] = mapCursor.proj(c.pos_x[j], c.pos_y ? c.pos_y[j] : 0, c.pos_z[j], false);
+      ctx.save();
+      ctx.shadowColor = p.color;
+      ctx.shadowBlur = 10;
+      ctx.fillStyle = filled ? p.color : "#0b1520";
+      ctx.strokeStyle = filled ? "#fff" : p.color;
+      ctx.lineWidth = filled ? 2 : 2.5;
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      ctx.restore();
+    };
+    for (const p of state.picks)
+      if (p.data && p !== ref) dot(p, lowerBound(p.data.dist, dist), 4.5);
+    dot(ref, ri, 6);  // reference last, on top
   };
-  for (const p of state.picks)
-    if (p.data && p !== ref) dot(p, lowerBound(p.data.dist, dist), 4.5);
-  dot(ref, ri, 6);  // reference last, on top
+  if (mapCursor.pin != null) markAt(mapCursor.pin, false);
+  if (mapCursor.idx != null) markAt(mapCursor.idx, true);
 }
 
 /* screen-space contact markers of the last drawMap, for right-click hit
@@ -1089,7 +1107,7 @@ function drawMap() {
   mapCursor.snap.width = canvas.width;
   mapCursor.snap.height = canvas.height;
   mapCursor.snap.getContext("2d").drawImage(canvas, 0, 0);
-  if (mapCursor.idx != null) drawMapMarker();
+  if (mapCursor.idx != null || mapCursor.pin != null) drawMapMarker();
 }
 
 /* ---------------- export (issue #29) ---------------- */
@@ -1198,6 +1216,25 @@ function syncZoom(u) {
   }
 }
 
+/* dashed vertical marker on every chart at the pinned track position */
+function drawPinLine(u) {
+  const ref = refPick();
+  if (mapCursor.pin == null || !ref || !ref.data.dist.length) return;
+  const x = ref.data.dist[Math.min(mapCursor.pin, ref.data.dist.length - 1)];
+  const cx = u.valToPos(x, "x", true);
+  if (cx < u.bbox.left || cx > u.bbox.left + u.bbox.width) return; // zoomed out of view
+  const ctx = u.ctx;
+  ctx.save();
+  ctx.strokeStyle = "rgba(255,255,255,0.55)";
+  ctx.setLineDash([4, 4]);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(cx, u.bbox.top);
+  ctx.lineTo(cx, u.bbox.top + u.bbox.height);
+  ctx.stroke();
+  ctx.restore();
+}
+
 function makeChart(el, title, xVals, seriesDefs, height = 150) {
   const opts = {
     title, width: el.clientWidth, height,
@@ -1207,6 +1244,24 @@ function makeChart(el, title, xVals, seriesDefs, height = 150) {
     hooks: {
       setCursor: [(u) => setMapCursor(u.cursor.idx ?? null)],
       setScale: [(u, key) => { if (key === "x") syncZoom(u); }],
+      draw: [drawPinLine],
+      ready: [(u) => {
+        // click pins the hovered spot; a drag is uPlot's zoom, not a click,
+        // and the second click of a double is skipped (dblclick = reset both)
+        let downX = null;
+        u.over.addEventListener("mousedown", (e) => { downX = e.clientX; });
+        u.over.addEventListener("click", (e) => {
+          if (e.detail > 1) return;
+          if (downX != null && Math.abs(e.clientX - downX) > 3) return;
+          togglePin(u.cursor.idx ?? null);
+        });
+        u.over.addEventListener("dblclick", () => {
+          if (mapCursor.pin == null) return;
+          mapCursor.pin = null;
+          drawMapMarker();
+          for (const c of state.charts) c.redraw();
+        });
+      }],
     },
     scales: { x: { time: false } },
     // x is DistanceTraveled progress: on real FH6 circuits it is a per-route
@@ -1362,7 +1417,8 @@ function renderRawSection() {
     }
   }
   holder.appendChild(table);
-  if (mapCursor.idx != null) updateRawTable(mapCursor.idx);
+  const idx = mapCursor.idx ?? mapCursor.pin;
+  if (idx != null) updateRawTable(idx);
 }
 
 /* Fill every cell with the values at the hovered track position. The cursor
@@ -1376,7 +1432,8 @@ function updateRawTable(idx) {
   rawView.lastIdx = idx;
   const ri = Math.min(idx, ref.data.dist.length - 1);
   const dist = ref.data.dist[ri];
-  $("#raw-pos").textContent = `— @ track position ${Math.round(dist)}`;
+  const pinned = mapCursor.idx == null && idx === mapCursor.pin;
+  $("#raw-pos").textContent = `— @ track position ${Math.round(dist)}${pinned ? " · pinned" : ""}`;
   const at = rawView.cols.map((p) =>
     p === ref ? ri : Math.min(lowerBound(p.data.dist, dist), p.data.dist.length - 1));
   for (const row of rawView.rows) {

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -781,13 +781,10 @@ function drawMap() {
   const three = state.mapMode === "3d";
   canvas.style.cursor = three || mapView.zoom > 1 ? "grab" : "default";
   // the speed/slip gradient only exists for a lone lap; in an overlay the
-  // colors identify laps (issue #30) and the select would mislead
-  const colorSel = $("#color-mode");
-  if (colorSel) {
-    colorSel.disabled = multi;
-    colorSel.title = multi
-      ? "colors identify laps while comparing — keep a single lap to color by telemetry" : "";
-  }
+  // colors identify laps (issue #30), so the select disappears entirely — a
+  // merely-disabled control still looked clickable and confused people
+  const colorWrap = $("#color-wrap");
+  if (colorWrap) colorWrap.style.display = multi ? "none" : "";
   if (!ref) { // the side stats and color legend describe the reference lap -
     $("#map-side").innerHTML = "";      // don't let them show a lap that was untagged
     $("#legend-scale").innerHTML = "";

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -395,6 +395,26 @@ function pickLap(lapId) {
   if (lap) addPick(lap, state.session);
 }
 
+/* overlaying laps from different routes is allowed (route_id null = each
+   unidentified session counts as its own route) but the traces live in each
+   route's own world coordinates, so nothing will line up. Warn with a modal
+   the moment an overlay first crosses routes — once per episode, re-armed
+   when the tray is back to a single route — on top of the tray badge. */
+let warnedCrossRoute = false;
+function crossRoute() {
+  return new Set(state.picks.map((p) => p.session.route_id ?? `s${p.session.id}`)).size > 1;
+}
+function maybeWarnCrossRoute() {
+  if (!crossRoute()) { warnedCrossRoute = false; return; }
+  if (warnedCrossRoute) return;
+  warnedCrossRoute = true;
+  uiAlert("⚠ Comparing laps from different routes",
+    "The picked laps were recorded on different routes. Positions are world "
+    + "coordinates, so the map overlay and the distance-aligned charts will "
+    + "not line up — Δ time and racing-line spread are only meaningful "
+    + "between laps of the same route.");
+}
+
 /* single funnel for "the pick set changed": re-render rows, tray, map, charts.
    A reference change invalidates the zoom window and the hover index — both
    live on the reference lap's distance axis. */
@@ -412,6 +432,7 @@ function renderPicks() {
   drawMap();
   drawCharts();
   renderRawSection();
+  maybeWarnCrossRoute();
 }
 
 function renderTray() {
@@ -457,11 +478,10 @@ function renderTray() {
     el.appendChild(chip);
   }
   // overlaying different routes is allowed but rarely what you want
-  const routes = new Set(state.picks.map((p) => p.session.route_id ?? `s${p.session.id}`));
-  if (routes.size > 1) {
+  if (crossRoute()) {
     const warn = document.createElement("span");
     warn.className = "tray-warn";
-    warn.textContent = "⚠ laps from different routes — overlay may not align";
+    warn.textContent = "⚠ laps from different routes — the overlay will not align";
     el.appendChild(warn);
   }
   const clear = document.createElement("button");

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -184,11 +184,12 @@ async function selectSession(id) {
       saveSettings({ defaultMapMode: state.mapMode });
       for (const x of document.querySelectorAll("#map-mode button"))
         x.classList.toggle("active", x === b);
-      $("#map-hint").style.display = state.mapMode === "3d" ? "" : "none";
+      resetMapView(); // a 2D pan/zoom makes no sense under the 3D projection
+      updateMapHint();
       drawMap();
     };
   }
-  $("#map-hint").style.display = state.mapMode === "3d" ? "" : "none";
+  updateMapHint();
   bindMapDrag($("#trackmap"));
   bindMapContext($("#trackmap"));
 
@@ -602,7 +603,18 @@ function speedColor(v, lo, hi) {
 }
 
 /* 3D view state: yaw is user-draggable; the tilt is a fixed axonometric angle */
-const map3d = { yaw: -0.9, dragging: false, dragX: 0, dragYaw: 0 };
+const map3d = { yaw: -0.9, drag: null };
+
+/* map viewport on top of the fit-to-canvas projection, shared by 2D and 3D:
+   wheel zooms about the cursor, dragging pans (2D always, 3D with Shift held —
+   a plain 3D drag keeps rotating). zoom 1 = the classic full-fit frame. */
+const mapView = { zoom: 1, panX: 0, panY: 0 };
+
+function resetMapView() {
+  mapView.zoom = 1;
+  mapView.panX = 0;
+  mapView.panY = 0;
+}
 
 /* chart cursor -> map marker: drawMap caches its finished frame plus the
    world->canvas projection, so hovering a chart only blits the cache and
@@ -700,22 +712,52 @@ function bindMapContext(canvas) {
   });
 }
 
+function updateMapHint() {
+  const el = $("#map-hint");
+  if (!el) return;
+  el.style.display = "";
+  el.textContent = state.mapMode === "3d"
+    ? "↔ drag to rotate · scroll to zoom · shift-drag to pan · double-click resets"
+    : "scroll to zoom · drag to pan · double-click resets";
+}
+
 function bindMapDrag(canvas) {
   canvas.addEventListener("pointerdown", (e) => {
-    if (state.mapMode !== "3d") return;
-    map3d.dragging = true;
-    map3d.dragX = e.clientX;
-    map3d.dragYaw = map3d.yaw;
+    const rotate = state.mapMode === "3d" && !e.shiftKey;
+    if (!rotate && mapView.zoom <= 1) return; // nothing to pan at full fit
+    map3d.drag = {
+      rotate, x: e.clientX, y: e.clientY,
+      yaw: map3d.yaw, panX: mapView.panX, panY: mapView.panY,
+    };
     canvas.setPointerCapture(e.pointerId);
   });
   canvas.addEventListener("pointermove", (e) => {
-    if (!map3d.dragging) return;
-    map3d.yaw = map3d.dragYaw + (e.clientX - map3d.dragX) * 0.008;
+    const d = map3d.drag;
+    if (!d) return;
+    if (d.rotate) {
+      map3d.yaw = d.yaw + (e.clientX - d.x) * 0.008;
+    } else {
+      mapView.panX = d.panX + (e.clientX - d.x);
+      mapView.panY = d.panY + (e.clientY - d.y);
+    }
     drawMap();
   });
-  const stop = () => { map3d.dragging = false; };
+  const stop = () => { map3d.drag = null; };
   canvas.addEventListener("pointerup", stop);
   canvas.addEventListener("pointercancel", stop);
+  // wheel: zoom about the cursor, so what you point at stays put
+  canvas.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    const zoom = Math.min(12, Math.max(1, mapView.zoom * Math.exp(-e.deltaY * 0.002)));
+    if (zoom === mapView.zoom) return;
+    const k = zoom / mapView.zoom;
+    mapView.panX = e.offsetX - (e.offsetX - mapView.panX) * k;
+    mapView.panY = e.offsetY - (e.offsetY - mapView.panY) * k;
+    mapView.zoom = zoom;
+    if (zoom === 1) { mapView.panX = 0; mapView.panY = 0; }
+    drawMap();
+  }, { passive: false });
+  canvas.addEventListener("dblclick", () => { resetMapView(); drawMap(); });
 }
 
 function drawMap() {
@@ -737,7 +779,7 @@ function drawMap() {
   const ref = refPick();
   const multi = state.picks.length >= 2;  // overlay mode: solid distinct colors
   const three = state.mapMode === "3d";
-  canvas.style.cursor = three ? "grab" : "default";
+  canvas.style.cursor = three || mapView.zoom > 1 ? "grab" : "default";
   // the speed/slip gradient only exists for a lone lap; in an overlay the
   // colors identify laps (issue #30) and the select would mislead
   const colorSel = $("#color-mode");
@@ -815,7 +857,9 @@ function drawMap() {
   const offY = (cssH - (pMaxY - pMinY) * scale) / 2 - pMinY * scale;
   const P = (x, y, z, ground) => {
     const [sx, sy] = raw(x, y, z, ground);
-    return [sx * scale + offX, sy * scale + offY];
+    // the user viewport (wheel zoom + pan) sits on top of the full fit
+    return [(sx * scale + offX) * mapView.zoom + mapView.panX,
+            (sy * scale + offY) * mapView.zoom + mapView.panY];
   };
   const at = (d, i, ground) => {
     const c = d.channels;


### PR DESCRIPTION
## Summary

Five small analysis-page fixes bundled into one PR (per owner request — no PR flood):

- **Track map zoom** — the 3D map advertised rotation only and had no zoom at all. Scroll now zooms about the cursor (2D and 3D), drag pans in 2D and Shift-drag pans in 3D (plain 3D drag still rotates), double-click resets to the full-fit frame. The map hint spells out the gestures per mode.
- **Color select in overlay mode** — the speed/tire-slip select was disabled while comparing laps but didn't look it, inviting dead clicks. The whole control is now hidden during an overlay and returns with a single lap.
- **Click-to-pin cursor point** — clicking a comparison chart pins that track position: hollow ring on the map, dashed line on every chart. Hover still shows live values; when the cursor leaves the charts, the raw-data table and map marker fall back to the pin (labelled "· pinned"). Click the same spot again — or double-click, which also resets zoom — to unpin. With no pin, the old last-hovered behavior is unchanged.
- **Cross-route overlay warning** — a modal now fires the first time an overlay crosses routes (re-armed when the tray is back to one route), and the persistent tray note is restyled as a bordered warning badge instead of small muted text.
- **Car list: ordinal 3304** — the refresh layer was working correctly: remote main and the bundled list were both 638 entries, so 638 was the truthful count; the list itself was stale. This lands the pending community report (1990 Alfa Romeo SE 048SP → 639 cars); installs pick it up within a day via the daily refresh. Closes #37.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Event-detection change (recorder / `laps.py`)
- [ ] Docs only
- [ ] Refactor / chore

## How was it tested?

Browser-verified from source (uvicorn + scratch `DATA_DIR`) against a DB seeded via `tests/harness`: two 3-lap race sessions on one route + a sprint on a second route. Exercised every flow with dispatched events: wheel zoom/pan/rotate/reset in both map modes, color-select visibility across 1→2 picks, the full pin lifecycle (pin → hover elsewhere → leave → fall back to pin → unpin, and double-click clear), and the cross-route modal + badge (including re-arm after dropping back to one route). No console errors. `/api/cars` reports 639 with the downloaded 638-entry list overlaid — the newer bundled entry survives the merge.

## Checklist

- [x] Branched off `main` as `feat/…` or `fix/…`.
- [x] `ruff check .` passes.
- [x] `python app/telemetry/packet.py` (packet self-test) passes.
- [x] `pytest -q` passes (69 passed).
- [x] Docs updated where relevant — user-facing hint text updated in-page (analysis.html); no detection/schema/API changes.
- [ ] For a new detection scenario: n/a.
- [x] Cross-file invariants kept in sync (see ARCHITECTURE.md "Cross-file invariants").

🤖 Generated with [Claude Code](https://claude.com/claude-code)