### PR TITLE
fix: reset map zoom/pan when switching sessions

### DIFF
--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -161,6 +161,7 @@ async function selectSession(id) {
   if (seq !== selectSeq) return;  // a newer selection landed; drop this payload
   state.laps = payload.laps;
   state.session = payload.session;  // PNG export captions from it
+  resetMapView();  // stale zoom/pan aimed at the old track's geometry (#48)
 
   const detail = $("#detail");
   detail.innerHTML = "";


### PR DESCRIPTION
## Summary

Fixes #48 — the track map's wheel-zoom/pan viewport (`mapView`) survived a session change, so selecting another track rendered it under the old track's zoom and pan, often entirely off-canvas (blank map).

`selectSession()` now calls `resetMapView()` when the new session payload lands, so every track opens at the classic full-fit frame. `reloadSession()` (same-session refresh after a manual edit) intentionally keeps the view.

## Verification

Verified in the browser against a source run with a scratch DB (two harness-seeded sessions):

1. Selected session A, wheel-zoomed the map to max (`mapView` = `{zoom: 12, panX: -4246, panY: -1848}` — the bug state).
2. Selected session B → `mapView` = `{zoom: 1, panX: 0, panY: 0}` and the canvas repainted the track at full fit (~4.8k painted pixels, not blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)