### PR TITLE
fix: qualify contact by impulse shape, not just magnitude

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,8 +227,33 @@ All the rules exist because some real behavior broke a naive version:
   (LS_KEEP_DISCARDED captures and reprocessed sessions set it).
 - Dirty-lap inference: rewind = lap clock below its high-water mark while
   distance doesn't grow (per-frame comparison misses gradual scrubs — that bug
-  shipped once); contact = ground-plane |accel| ≥ 45 m/s². Stored as
-  `laps.flags` ("rewind,contact"). **Jump landings are excused:** a spike while
+  shipped once); contact = ground-plane |accel| ≥ 45 m/s² **that also looks
+  like an impulse** (below). Stored as `laps.flags` ("rewind,contact").
+- **45 m/s² alone is not contact — the burst must have an impact's *shape*.**
+  That threshold assumed no car corners that hard on tires; downforce cars
+  break the assumption, sustaining 5–7.7 g of pure lateral g through fast
+  corners, so they used to flag *every* lap (session 187, Alfa Group C: 530
+  markers in 39 laps, 13.6/lap, all 39 flagged including the clean best).
+  Magnitude can't separate the two; the rise can. Aero load builds over
+  hundreds of ms, an impact is an impulse — so a non-landing burst counts only
+  when some frame of it either gained `IMPACT_JERK` (30 m/s², ~3 g) over the
+  previous frame, or reached `IMPACT_PEAK` (98 m/s², ~10 g). `impulsive()` in
+  laps.py is the one implementation, imported by `_scan_lap`; dashboard.js
+  mirrors it. Swept over all 70 stored sessions / 1813 bursts (2026-07-26,
+  same dump/hand-classify method as the landing classifier): of the 1334
+  bursts rising slower than 1 g/frame **not one** reached 10 g, and the
+  histogram has an empty valley at 1.5–3 g/frame. Effect is *selective*, not
+  merely stricter — 187: 530→46, 129 (Furai): 338→7, A-641 session 117: 82→0,
+  while cross-country/dirt sessions barely move (55: 7→6, 103: 5→5, 8: 13→9)
+  and the low-downforce control (146, Diablo SV) was 0 before and after.
+  Only jerk is *causal* (one frame of history), which is why it and not burst
+  duration or speed-delta drives the live recorder and dashboard.js.
+  `IMPACT_JERK_DT_MAX` (0.05 s) ignores a jerk read across a stream gap or a
+  rewind splice — the gap manufactures it. Rejected bursts are dropped
+  outright (issue #49).
+  **Jump landings are excused** and are classified *first*, so the impulse
+  gate never sees them (a touchdown slam is an impulse and would pass it):
+  a spike while
   airborne (all four `NormalizedSuspensionTravel` < 0.15 **and** all four
   `TireCombinedSlip` < 0.05 for ≥ 0.12 s — in flight wheels hang at full droop
   with zero tire force) or within 0.35 s of touchdown is a landing, not contact
@@ -242,7 +267,10 @@ All the rules exist because some real behavior broke a naive version:
   ones. **Known remaining limit:** light Rivals wall-scrapes stay below the
   threshold (false negatives; there is no lap-invalidated packet field to
   cross-check against) — tracked in
-  [issue #27](https://github.com/darcane/LapScope/issues/27). A wall hit inside the 0.35 s post-landing grace is also excused
+  [issue #27](https://github.com/darcane/LapScope/issues/27), and now more
+  tractable: with contact qualified by *shape*, `IMPACT_ACCEL` could be
+  lowered to reach light scrapes without re-flooding downforce cars (still
+  needs labeled scrape captures first). A wall hit inside the 0.35 s post-landing grace is also excused
   (accepted trade-off). Flags reset when a lap re-anchors (the WTA launch, a
   mid-session lap-timer start): pre-launch junk frames must not dirty lap 1.
   Test-fixture gotcha: `empty_fields()` zeroes suspension and slip, which
@@ -343,4 +371,5 @@ a row here, a test, and usually a simulator flag.
 | Track type: WTA | `--wta 3` | auto-tagged `wtc` (geometric laps) |
 | Track type: route inheritance | two events, same route | a tag set on the route's earlier session wins over telemetry for later ones |
 | Landing vs contact | `--duration 180 --dirty --jumps` | lap 2 `contact` (wall hit), all other laps clean despite hard jump landings; `/laps/{id}/data` tags landing bursts `landing: true` (amber on the map) |
+| Aero cornering vs contact | hand-built frames (`test_tracker.py`, `test_api.py`) | a burst that ramps past 45 m/s² and holds is *not* contact (no flag, no marker); a one-frame jump of `IMPACT_JERK` is, even mid-burst on top of aero load (issue #49) |
 | Race-mode gating | `--freeroam 35 --race 3` | chip FREE ROAM then RACE MODE; timer dashed in free roam; live map draws the race only |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -223,12 +223,16 @@ assert them here.
 - Teleport threshold 250 m: `WTA_TELEPORT_JUMP` (laps.py) = live-map jump reset
   (dashboard.js) = `POS_JUMP` (inspect_session.py).
 - Contact spike threshold + landing discrimination: `IMPACT_ACCEL`,
-  `AIRBORNE_SUSP_MAX`, `AIRBORNE_SLIP_MAX`, `AIRBORNE_MIN_S` and
+  `IMPACT_JERK`, `IMPACT_JERK_DT_MAX`, `IMPACT_PEAK`, `AIRBORNE_SUSP_MAX`,
+  `AIRBORNE_SLIP_MAX`, `AIRBORNE_MIN_S` and
   `LANDING_GRACE_S` (laps.py) drive the per-lap `contact` flag and the map
   collision markers (spikes while airborne / just after touchdown are jump
-  landings, not contact) — the `/laps/{id}/data` endpoint imports them and
-  tags each collision `landing: true/false`; `dashboard.js` duplicates all
-  five constants for the live map (keep the two in lockstep). The same
+  landings, not contact; everything else must also pass `impulsive()`, or it
+  is a downforce car cornering rather than a wall — issue #49) — the
+  `/laps/{id}/data` endpoint imports them **and `impulsive()` itself**, so the
+  live flag and the markers can't drift; `dashboard.js` duplicates all
+  eight constants *and* re-implements `impulsive()` for the live map (keep the
+  two in lockstep). The same
   airborne classifier also yields explicit jump segments (takeoff →
   touchdown): `/laps/{id}/data` returns them as `jumps`, `dashboard.js`
   tracks them live in `feedCollision`, and both maps render them through the

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -17,7 +17,8 @@ from pydantic import BaseModel
 from .. import __version__, cars
 from ..cars import CAR_NAMES
 from ..recorder.laps import (AIRBORNE_MIN_S, AIRBORNE_SLIP_MAX,
-                             AIRBORNE_SUSP_MAX, IMPACT_ACCEL, LANDING_GRACE_S)
+                             AIRBORNE_SUSP_MAX, IMPACT_ACCEL, LANDING_GRACE_S,
+                             impulsive)
 from ..recorder.reprocess import reprocess_session
 from ..recorder.store import lap_anchor, lap_span
 from ..telemetry.packet import FIELDS, empty_fields, pack, parse
@@ -377,7 +378,10 @@ def _scan_lap(rows: list[tuple[float, bytes]], start_dist: float):
     the peak's frame time t is the handle a dismissal edit anchors to.
     Spikes while airborne or right after touchdown are jump landings, not
     contact (same classification as the recorder) - tagged, not dropped, so
-    the map can still show where a jump bottomed out.
+    the map can still show where a jump bottomed out. Every other burst must
+    also look like an impact rather than aero load (impulsive(), laps.py) or
+    it is dropped: downforce cars cross the threshold in fast corners and
+    used to bury the map in false markers (issue #49).
 
     Jump segments: the same airborne classifier also yields explicit flights
     (every wheel unloaded for >= AIRBORNE_MIN_S). Each is returned as a
@@ -397,6 +401,8 @@ def _scan_lap(rows: list[tuple[float, bytes]], start_dist: float):
     jumps: list[dict] = []
     peak: tuple | None = None  # (g, t, d, frame) of the current impact burst
     burst_landing = True       # all frames of the burst classified as landing
+    burst_impact = False       # some frame of the burst looked like an impact
+    prev_g: tuple[float, float] | None = None  # previous frame's (t, g)
     air_since: float | None = None
     air_start: tuple | None = None  # (t, d, frame) of the first airborne frame
     grace_until = 0.0
@@ -421,6 +427,16 @@ def _scan_lap(rows: list[tuple[float, bytes]], start_dist: float):
             elif jumps:
                 jumps[-1]["hard"] = True
                 jumps[-1]["g"] = max(jumps[-1]["g"] or 0.0, peak_g)
+
+    def emit_burst() -> None:
+        """Close the burst that just ended. Landings are always emitted (the
+        map draws them amber and they mark their jump hard); a non-landing
+        burst only counts when it looked like an impact rather than a
+        downforce car leaning on its aero - see impulsive() in laps.py.
+        Rejected bursts are dropped outright: they are ordinary cornering,
+        not an event with anything to inspect (issue #49)."""
+        if burst_landing or burst_impact:
+            emit(peak, burst_landing)
 
     def emit_jump(start: tuple, land: tuple) -> None:
         nonlocal pending_hard
@@ -451,17 +467,19 @@ def _scan_lap(rows: list[tuple[float, bytes]], start_dist: float):
         g = math.hypot(p["accel_x"], p["accel_z"])
         if g >= IMPACT_ACCEL:
             if peak is None:
-                peak, burst_landing = (g, t, d, p), True
+                peak, burst_landing, burst_impact = (g, t, d, p), True, False
             elif g > peak[0]:
                 peak = (g, t, d, p)
             burst_landing = burst_landing and (flying or t < grace_until)
+            burst_impact = burst_impact or impulsive(t, g, prev_g)
         elif peak is not None:
-            emit(peak, burst_landing)
+            emit_burst()
             peak = None
+        prev_g = (t, g)
     # resolve a trailing burst BEFORE a trailing flight: a trace ending
     # mid-burst mid-flight must hand its peak to the segment emitted next
     if peak is not None:  # impact ran to the last kept frame
-        emit(peak, burst_landing)
+        emit_burst()
     if air_since is not None and kept and kept[-1][0] - air_since >= AIRBORNE_MIN_S:
         emit_jump(air_start, kept[-1])  # lap trace ended mid-flight
 

--- a/app/recorder/laps.py
+++ b/app/recorder/laps.py
@@ -123,6 +123,28 @@ WET_FRAME_FRACTION = 0.02     # fraction of wet frames to auto-tag "wet"
 REWIND_TIME_JUMP = 0.5        # lap clock going back by this much = rewind
 IMPACT_ACCEL = 45.0           # m/s^2 in the ground plane (~4.6 g) = contact
 
+# Aero-cornering discrimination (issue #49, calibrated on the stored captures:
+# same dump/hand-classify/DB-sweep method as the landing classifier). 45 m/s^2
+# assumed no car corners that hard on tires alone - false for downforce cars,
+# which sustain 5-7.7 g of pure lateral g through fast corners and so flagged
+# EVERY lap (session 187: 530 markers in 39 laps). Magnitude alone can't
+# separate them; the shape of the burst can. Aero load ramps in over hundreds
+# of ms, an impact is an impulse: swept over 1813 real bursts, jerk and peak
+# agree almost perfectly (of the 1334 bursts rising slower than 1 g/frame, not
+# one reached 10 g). Jerk needs only the previous frame, so the live recorder
+# and dashboard.js apply it with no buffering - unlike burst duration or speed
+# delta, which need the burst to finish. Mirrored in dashboard.js (lockstep).
+IMPACT_JERK = 30.0            # m/s^2 of ground-plane g gained in ONE frame
+                              # (~3 g): the empty valley between the aero
+                              # population and real hits (flat either side;
+                              # past ~3.5 g real cross-country hits drop out)
+IMPACT_JERK_DT_MAX = 0.05     # s: a jerk measured across a stream gap is the
+                              # gap's doing, not an impact's - 2 of the swept
+                              # detections came from >100 ms gaps
+IMPACT_PEAK = 98.0            # m/s^2 (~10 g): no swept aero burst passed
+                              # ~7.7 g, so this floor stands alone as contact
+                              # even when the impulse got smeared over frames
+
 # Airborne / jump-landing discrimination (verified on real cross-country,
 # session 55: 5 of its 12 contact spikes were hard jump-landings). In flight
 # every wheel hangs at full droop with zero tire force; on the ground even a
@@ -178,6 +200,24 @@ TRACK_MIN_DRIVE_S = 30.0       # too little driving to judge a surface
 # keep sessions that would otherwise be discarded (no completed laps) - for
 # capturing event types the segmentation doesn't recognize yet
 KEEP_DISCARDED = os.environ.get("LS_KEEP_DISCARDED", "0").lower() not in ("", "0", "false")
+
+
+def impulsive(t: float, g: float, prev: tuple[float, float] | None) -> bool:
+    """Does this over-threshold frame look like an impact rather than a
+    downforce car simply cornering? Either the ground-plane g jumped by
+    IMPACT_JERK in a single frame, or it reached IMPACT_PEAK - a level no
+    measured aero cornering approaches. `prev` is the previous frame's
+    (t, ground-plane g), or None when there isn't one (a session opening
+    mid-spike stays conservative: peak floor only). Shared by the recorder
+    and _scan_lap (api/routes.py) so the live flag and the map markers can
+    never disagree; dashboard.js mirrors it for the live map."""
+    if g >= IMPACT_PEAK:
+        return True
+    if prev is None:
+        return False
+    dt = t - prev[0]
+    # a jerk measured across a stream gap is the gap's doing, not an impact's
+    return 0.0 < dt <= IMPACT_JERK_DT_MAX and g - prev[1] >= IMPACT_JERK
 
 
 def suggest_track_type(*, geometric_laps: int, drive_s: float, drive_n: int,
@@ -256,6 +296,7 @@ class SessionTracker:
         self._air_since: float | None = None   # start of the current flight
         self._landing_grace_until = 0.0        # spikes before this t = landing
         self._over_impact = False              # inside a spike burst (log once)
+        self._prev_g: tuple[float, float] | None = None  # (t, ground-plane g)
         self._route_assigned = False
         self._route_id: int | None = None
         self._geometric_laps = 0
@@ -361,7 +402,10 @@ class SessionTracker:
                 if not self._over_impact:
                     log.info("Session %s: jump landing (%.0f m/s^2) - not contact",
                              self.session_id, g)
-            else:
+            elif impulsive(t, g, self._prev_g):
+                # tested every frame of the burst, not just its rising edge: a
+                # hit taken while the car is ALREADY loaded up mid-corner
+                # starts the burst gently and only spikes later
                 if "contact" not in self._lap_flags:
                     log.info("Session %s: contact spike (%.0f m/s^2), flagging lap",
                              self.session_id, g)
@@ -369,6 +413,7 @@ class SessionTracker:
             self._over_impact = True
         else:
             self._over_impact = False
+        self._prev_g = (t, g)
         delta = self._lap_logic(t, frame)
         if t - self._last_flush >= FLUSH_INTERVAL:
             self.flush()
@@ -446,6 +491,7 @@ class SessionTracker:
         self._air_since = None
         self._landing_grace_until = 0.0
         self._over_impact = False
+        self._prev_g = None
         self._route_assigned = False
         self._route_id = None
         self._geometric_laps = 0
@@ -571,6 +617,7 @@ class SessionTracker:
         self._air_since = None
         self._landing_grace_until = 0.0
         self._over_impact = False
+        self._prev_g = None
         self._route_id = None
         self._geometric_laps = 0
         self._prev_on_line = True

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -30,13 +30,29 @@ const shiftLights = document.querySelectorAll("#shift-lights i");
 const LIVEMAP_CAP = 4000;
 // ground-plane acceleration (m/s^2) that counts as a contact/collision, plus
 // the airborne/jump-landing discrimination (a spike while airborne or right
-// after touchdown is a landing, not contact); mirrors IMPACT_ACCEL /
-// AIRBORNE_* / LANDING_GRACE_S in app/recorder/laps.py (keep in lockstep).
+// after touchdown is a landing, not contact) and the impulse test that keeps
+// a downforce car's cornering load from reading as a wall (issue #49);
+// mirrors IMPACT_* / AIRBORNE_* / LANDING_GRACE_S and impulsive() in
+// app/recorder/laps.py (keep in lockstep).
 const IMPACT_ACCEL = 45;
+const IMPACT_JERK = 30;
+const IMPACT_JERK_DT_MAX = 0.05;
+const IMPACT_PEAK = 98;
 const AIRBORNE_SUSP_MAX = 0.15;
 const AIRBORNE_SLIP_MAX = 0.05;
 const AIRBORNE_MIN_S = 0.12;
 const LANDING_GRACE_S = 0.35;
+
+// mirrors impulsive() in laps.py: an impact either jumps IMPACT_JERK in one
+// frame (only trustworthy across a sane frame gap) or reaches IMPACT_PEAK,
+// which no measured aero cornering approaches. prev = [t, g] or null.
+function impulsive(t, g, prev) {
+  if (g >= IMPACT_PEAK) return true;
+  if (!prev) return false;
+  const dt = t - prev[0];
+  return dt > 0 && dt <= IMPACT_JERK_DT_MAX && g - prev[1] >= IMPACT_JERK;
+}
+
 const liveMap = {
   pts: [],         // [x, z] world points
   last: null,      // last stored point
@@ -46,6 +62,8 @@ const liveMap = {
   hits: [],        // [x, z] world points where a contact spike fired
   jumps: [],       // {x0, z0, x1, z1, hard} takeoff -> touchdown segments
   overImpact: false, // above the threshold last frame (edge-detect one hit/impact)
+  burstSparked: false, // this burst already pushed its marker (one per impact)
+  prevG: null,     // previous frame's [t, ground-plane g], for the impulse test
   airSince: null,  // when the current all-wheels-unloaded stretch began
   airStart: null,  // [x, z] where that stretch began (the takeoff point)
   graceUntil: 0,   // spikes before this time are jump landings, not contact
@@ -62,6 +80,8 @@ function resetLiveMap(sessionId) {
   liveMap.hits = [];
   liveMap.jumps = [];
   liveMap.overImpact = false;
+  liveMap.burstSparked = false;
+  liveMap.prevG = null;
   liveMap.airSince = null;
   liveMap.airStart = null;
   liveMap.graceUntil = 0;
@@ -80,6 +100,8 @@ function mapActive(f) {
 function feedCollision(f) {
   if (f.session_id == null || !mapActive(f) || f.session_id !== liveMap.session) {
     liveMap.overImpact = false;
+    liveMap.burstSparked = false;
+    liveMap.prevG = null;
     liveMap.airSince = null;
     liveMap.airStart = null;
     liveMap.pendingHard = false;
@@ -105,24 +127,34 @@ function feedCollision(f) {
     liveMap.airSince = null;
   }
   const flying = liveMap.airSince != null && t - liveMap.airSince >= AIRBORNE_MIN_S;
-  if (Math.hypot(f.accel_x, f.accel_z) >= IMPACT_ACCEL) {
+  const g = Math.hypot(f.accel_x, f.accel_z);
+  if (g >= IMPACT_ACCEL) {
     if (!liveMap.overImpact) {
+      liveMap.burstSparked = false;
       if (flying) {
         // mid-flight spike: its jump isn't pushed until touchdown - hold it
         // instead of marking the previous jump hard (issue #41)
         liveMap.pendingHard = true;
+        liveMap.burstSparked = true;   // a landing never sparks
       } else if (t < liveMap.graceUntil) {
         // the landing of the jump that just ended: mark its glyph hard, no spark
         const j = liveMap.jumps[liveMap.jumps.length - 1];
         if (j) j.hard = true;
-      } else {
-        liveMap.hits.push([f.pos_x, f.pos_z]);
+        liveMap.burstSparked = true;
       }
+    }
+    // the spark waits for the frame that actually looks like an impact, which
+    // may not be the burst's first: a hit taken mid-corner starts out looking
+    // like the aero load it is riding on top of (issue #49)
+    if (!liveMap.burstSparked && impulsive(t, g, liveMap.prevG)) {
+      liveMap.hits.push([f.pos_x, f.pos_z]);
+      liveMap.burstSparked = true;
     }
     liveMap.overImpact = true;
   } else {
     liveMap.overImpact = false;
   }
+  liveMap.prevG = [t, g];
 }
 
 function feedLiveMap(f) {

--- a/docs/wiki/Event-Detection.md
+++ b/docs/wiki/Event-Detection.md
@@ -135,8 +135,25 @@ The packet has no lap-invalidated field, so LapScope infers dirtiness:
   mark misses gradual scrubbing — that bug shipped once.) Rewound-over
   stretches are trimmed from the charts and the map, so only the
   finally-driven line remains.
-- **💥 Contact** — a ground-plane acceleration spike ≥ 45 m/s², beyond
-  anything tires can generate.
+- **💥 Contact** — a ground-plane acceleration spike ≥ 45 m/s² that also
+  *arrives* like an impact (below), rather than building up like cornering
+  load.
+
+**Downforce cars corner harder than tires alone can.** 45 m/s² is ~4.6 g, and
+that was assumed to be past any car's grip — but ground-effect prototypes pull
+**5–7.7 g of pure lateral g** through fast corners at full throttle. On those
+cars every quick corner used to register as a contact: a Group C Alfa logged
+530 markers across 39 laps and had *every* lap flagged 💥, including its
+cleanest one.
+
+So magnitude alone isn't enough — the spike also has to *arrive* like an
+impact. Aero load builds over several tenths of a second; a wall arrives in a
+single frame. A spike therefore only counts as contact when it jumps by
+≥ 30 m/s² between two consecutive frames, or reaches 98 m/s² (~10 g) outright,
+a level no measured cornering came close to. Swept over every stored session:
+of the 1,300-odd bursts that built up gradually, not one ever reached 10 g.
+Fast corners stop drawing markers while genuine hits — including the
+low-speed, low-g ones on dirt and cross-country — are untouched.
 
 **Jump landings are excused.** Horizon being Horizon, hard landings spike the
 accelerometer exactly like a wall. A spike while **airborne** — all four
@@ -158,6 +175,11 @@ but its lateral force is far below the contact threshold — and there is no
 packet field to cross-check against. Light scrapes are therefore missed (and a
 wall hit inside the 0.35 s post-landing grace is excused). Accepted trade-offs,
 tracked in [issue #27](https://github.com/darcane/LapScope/issues/27).
+
+**Already recorded a session before this landed?** The map markers are worked
+out as you open a lap, so they clean themselves up right away. The 💥 flag in
+the lap table is what the recorder decided at the time — hit **Reprocess** on
+the session to have it re-decided.
 
 Flags reset when a lap re-anchors (a WTA launch, a mid-session lap-timer
 start), so pre-launch junk frames never dirty lap 1.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,6 +181,54 @@ def test_mid_flight_spike_marks_its_own_jump_hard():
     assert collisions and all(c["landing"] for c in collisions)
 
 
+def test_aero_cornering_bursts_are_dropped_impacts_kept():
+    """Issue #49: a downforce car's cornering load crosses the contact
+    threshold and used to draw a marker per fast corner. Only a burst that
+    looks like an impulse survives - here one long aero corner (dropped) and
+    one wall hit (kept), so exactly one marker comes back."""
+    from app.api.routes import _scan_lap
+    from app.telemetry.packet import empty_fields, pack
+
+    def frame(d, gx):
+        f = empty_fields()
+        f["is_race_on"] = 1
+        f["distance_traveled"] = d
+        f["pos_x"] = d
+        f["norm_susp_travel"] = [0.5] * 4     # grounded: not a jump landing
+        f["tire_combined_slip"] = [0.3] * 4
+        f["accel_x"] = gx
+        return pack(f)
+
+    rows: list[tuple[float, bytes]] = []
+    t, d = 0.0, 0.0
+
+    def add(gs):
+        nonlocal t, d
+        for gx in gs:
+            rows.append((t, frame(d, gx)))
+            t += 1 / 60
+            d += 0.7
+
+    add([0.0] * 10)
+    add([2.0 * i for i in range(31)])   # aero builds to 60 m/s^2 over 0.5 s...
+    add([60.0] * 30)                    # ...holds through the corner...
+    add([60.0 - 2.0 * i for i in range(31)])  # ...and unwinds. No impulse.
+    add([0.0] * 10)
+    aero_only = len(rows)
+    assert _scan_lap(rows, 0.0)[1] == []          # not one marker so far
+
+    add([0.0, 70.0, 65.0, 50.0])        # a wall: 0 -> 70 m/s^2 in one frame
+    add([0.0] * 10)
+
+    _, collisions, jumps = _scan_lap(rows, 0.0)
+    assert jumps == []
+    assert len(collisions) == 1                    # the wall, not the corner
+    hit = collisions[0]
+    assert not hit["landing"] and hit["g"] > 7.0   # 70 m/s^2 peak, ~7.1 g
+    # and it is the late burst, not anything from the aero stretch
+    assert hit["t"] > rows[aero_only - 1][0]
+
+
 def test_lap_data_no_jumps_on_a_flat_lap(tmp_path):
     """A plain circuit lap never leaves the ground: jumps must be empty."""
     from app.api.routes import lap_data

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -31,11 +31,12 @@ class Driver:
                       norm_susp_travel=[0.5] * 4, tire_combined_slip=[0.3] * 4)
         self.t = 0.0
 
-    def send(self, **kw) -> dict:
+    def send(self, *, dt: float = 1 / 60, **kw) -> dict:
         """Advance one frame (race clock included unless overridden) and
-        return the tracker extras for it."""
-        self.t += 1 / 60
-        self.f["current_race_time"] += 1 / 60
+        return the tracker extras for it. dt widens the step to stage a
+        stream gap."""
+        self.t += dt
+        self.f["current_race_time"] += dt
         self.f.update(**kw)
         raw = pack(self.f)
         return self.tracker.on_frame(self.t, raw, parse(raw))
@@ -49,10 +50,12 @@ class Driver:
 
 
 def drive_circle(d: Driver, radius: float = 120.0, v: float = 40.0,
-                 laps: float = 1.3) -> None:
+                 laps: float = 1.3, accel=None) -> None:
     """Drive a circle through the launch point: one geometric (WTA) lap,
-    then far enough past it that the crossing finalizes on circle exit."""
+    then far enough past it that the crossing finalizes on circle exit.
+    accel(n) supplies the frame's lateral acceleration when given."""
     dist, total = 0.0, 2 * math.pi * radius * laps
+    n = 0
     while dist < total:
         dist += v / 60
         ang = dist / radius
@@ -60,7 +63,8 @@ def drive_circle(d: Driver, radius: float = 120.0, v: float = 40.0,
         # the car moves along (sin yaw, cos yaw), so yaw = pi/2 - angle
         d.send(pos_x=radius * math.sin(ang), pos_z=radius * (1 - math.cos(ang)),
                distance_traveled=dist, speed=v, yaw=math.pi / 2 - ang,
-               accel_x=0.0)
+               accel_x=accel(n) if accel else 0.0)
+        n += 1
 
 
 def test_pre_launch_contact_not_flagged_on_geometric_lap(tmp_path):
@@ -250,6 +254,62 @@ def test_off_line_roughness_cannot_fake_dirt(tmp_path):
         _course_drive(d, 8 * 60, rough=True, on_line=False)   # grass excursion
         _fly(d, 20, on_line=False)                            # ditch jump
     assert _finish_event_track_type(d) == "road"
+
+
+def test_sustained_aero_cornering_is_not_contact(tmp_path):
+    """Issue #49: a downforce car loading up through a fast corner crosses
+    IMPACT_ACCEL and stays there for most of a second, which used to flag
+    every such lap. Aero builds over hundreds of ms - no frame of it is an
+    impulse - so the lap must stay clean."""
+    d = Driver(tmp_path)
+
+    def aero(n):
+        if not 200 <= n < 290:
+            return 0.0
+        ramp = min(n - 200, 30) / 30          # 0 -> 1 over half a second
+        fade = min(289 - n, 30) / 30          # and back down again
+        return 60.0 * min(ramp, fade)         # peaks at 60 m/s^2, well over 45
+
+    drive_circle(d, accel=aero)
+    timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
+    assert len(timed) == 1
+    assert "contact" not in (timed[0]["flags"] or "")
+
+
+def test_impact_on_top_of_aero_load_still_flags(tmp_path):
+    """The burst starts as ordinary cornering and only spikes several frames
+    in (a wall clipped mid-corner). The impulse test therefore has to run on
+    every frame of the burst, not just its rising edge - and the spike stays
+    under IMPACT_PEAK so only the jerk can catch it."""
+    d = Driver(tmp_path)
+
+    def hit_mid_corner(n):
+        if not 200 <= n < 290:
+            return 0.0
+        if n == 250:
+            return 90.0          # +30 m/s^2 in one frame, still below 98
+        return 60.0              # already over IMPACT_ACCEL either side of it
+
+    drive_circle(d, accel=hit_mid_corner)
+    timed = [lap for lap in d.finish() if lap["lap_time"] is not None]
+    assert len(timed) == 1
+    assert "contact" in (timed[0]["flags"] or "")
+
+
+def test_impulsive_gate(tmp_path):
+    """The shared gate itself (laps.py), pinned at its edges."""
+    from app.recorder.laps import (IMPACT_JERK, IMPACT_JERK_DT_MAX,
+                                   IMPACT_PEAK, impulsive)
+
+    prev = (1.0, 50.0)
+    t = 1.0 + 1 / 60
+    assert impulsive(t, 50.0 + IMPACT_JERK, prev)        # a sharp jump
+    assert not impulsive(t, 50.0 + IMPACT_JERK - 1, prev)  # ...but not gentle
+    # the same jump read across a stream gap is the gap's doing, not an impact
+    assert not impulsive(1.0 + 4 * IMPACT_JERK_DT_MAX, 50.0 + IMPACT_JERK, prev)
+    # the peak floor stands alone, even with no previous frame to compare to
+    assert impulsive(t, IMPACT_PEAK, None)
+    assert not impulsive(t, IMPACT_PEAK - 1, None)
 
 
 def test_listener_fallback_keeps_frame_contract(tmp_path):


### PR DESCRIPTION
## Summary

Closes #49.

`IMPACT_ACCEL = 45 m/s²` (~4.6 g) assumed no car corners that hard on tires alone. Downforce cars break that assumption: ground-effect prototypes sustain **5–7.7 g of pure lateral g** through fast corners, so every quick corner registered as a contact. Session 187 (Alfa SE 048SP, Group C) drew **530 markers across 39 laps** — 13.6 per lap — with all 39 laps flagged `contact`, including its clean 0:43.241 best.

Magnitude alone can't separate the two populations; **the shape of the burst can**. Aero load builds over hundreds of milliseconds; an impact is an impulse. A non-landing burst now counts as contact only when some frame of it either:

- gained `IMPACT_JERK` (30 m/s², ~3 g) over the previous frame, or
- reached `IMPACT_PEAK` (98 m/s², ~10 g).

`IMPACT_JERK_DT_MAX` (0.05 s) ignores a jerk read across a stream gap or a rewind splice, where the gap itself manufactures it.

### Calibration

Swept all 70 stored sessions / 1813 non-landing bursts (same dump/hand-classify/DB-sweep method as the landing classifier). Onset jerk vs peak:

| jerk (g/frame) | peak <8 g | 8–10 g | ≥10 g |
|---|---|---|---|
| <1 | 1329 | 5 | **0** |
| 1–3 | 86 | 1 | 2 |
| 3–6 | 103 | 25 | 7 |
| ≥6 | 6 | 22 | **227** |

The histogram is bimodal with an empty valley at 1.5–3 g/frame, and of the 1334 bursts rising slower than 1 g/frame **not one** reached 10 g. The result is flat around the chosen threshold (1.5 g → 444 bursts kept, 3.0 → 392, 4.0 → 347); past ~3.5 g real cross-country hits start dropping out, so 3 g is the safe knee.

Jerk is also the only strong candidate that is **causal** — one frame of history — so the live recorder and `dashboard.js` apply it with no buffering. Burst duration and speed-delta were rejected for needing the burst to finish.

### Why not per-class thresholds

The original idea on the issue was scaling the threshold by `car_class`/PI. The sweep confirms the issue's own caveat: session 117 is **A-class, 641 PI** and floods with 82 markers, while some R-class 998 sessions barely do. Class doesn't predict downforce — and the live map carries no car metadata to scale by.

### Effect: selective, not merely stricter

Measured through the production path (the "before" column reproduces the issue's table exactly, confirming the harness matches production):

| Session | Car | markers | laps flagged |
|---|---|---|---|
| 187 | Alfa SE 048SP (S2 900) | 530 → **46** (13.6 → 1.2/lap) | 39/39 → 28/39 |
| 129 | Mazda Furai (R 987) | 338 → **7** | 16/16 → 5/16 |
| 117 | A 800, 641 PI | 82 → **0** | 4/4 → 0/4 |
| 55, 103, 8 | cross-country / dirt | 7→6, 5→5, 13→9 | unchanged |
| 146 | Diablo SV (low-downforce control) | 0 → 0 | 0/3 → 0/3 |

Downforce sessions collapse 10–45× while the sessions with genuine hits pass through intact. Session 187's 46 survivors are real shunts (peaks of 14–20 g, speed losses of 22/41/52/66/110 km/h) — that session was genuinely dirty, not misdetected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Event-detection change (recorder / `laps.py`)
- [ ] Docs only
- [ ] Refactor / chore

## How was it tested?

- `pytest -q` — 77 pass, 4 new:
  - a burst that ramps past 45 m/s² and holds is not contact (no flag, no marker)
  - a one-frame jump of `IMPACT_JERK` is — **including mid-burst on top of aero load**, which is why the gate runs on every frame of a burst rather than its rising edge
  - a slow ramp past `IMPACT_PEAK` still flags via the peak floor
  - `impulsive()` pinned at its edges, including the stream-gap guard
- **Real-data sweep through the production `_scan_lap`**, gate on vs forced off — the table above.
- **End-to-end over HTTP** against a snapshot of the real DB: session 187's best lap now returns zero markers, and after `POST /api/sessions/187/reprocess` its flag drops to `rewind` only.
- **`dashboard.js` verified frame-for-frame against the Python**: ran the real `feedCollision` in Node over recorded sessions — matches exactly (session 55: 6 sparks / 10 jumps / 5 hard landings; 129: 2 sparks). With the gate stubbed off the same frames give 8 and 25, confirming the gate is live rather than inert.

## Notes for the reviewer

- **`impulsive()` is imported, not duplicated.** It lives in `laps.py`; `_scan_lap` imports it so the per-lap flag and the map markers can't drift. `dashboard.js` mirrors it (the one unavoidable copy) and is covered by the frame-for-frame check above.
- **Landing classification is unchanged and still runs first** — a touchdown slam *is* an impulse and would pass this gate, so ordering matters.
- **Rejected bursts are dropped outright** rather than tagged: they're ordinary cornering, not an event with anything to inspect.
- **Existing sessions:** markers are computed at read time, so they clean up as soon as a lap is opened. The stored per-lap flag is recorder output and needs a **Reprocess**.
- **A plain "≥10 g floor"** — the shortcut suggested on the issue — would have broken the test suite: the simulator's wall hit (`lat_a += 60` for 8 frames) peaks at only ~6 g but jumps there in one frame. Worth knowing before anyone retunes this.
- **Bearing on #27** (light scrapes, false *negatives*): now more tractable. With contact qualified by shape, `IMPACT_ACCEL` could be lowered to reach light scrapes without re-flooding downforce cars. Still needs labelled scrape captures first — not attempted here.
- **Unrelated seam this made visible:** session 187 laps 26/33 keep the `contact` flag with no map marker. Both are genuine 18–20 g hits, but `_scan_lap`'s rewind/reverse trimming drops ~350 frames per lap because the car crashed and went backwards, so the impact isn't on the finally-driven line. Pre-existing — it was simply masked while every lap carried ~14 false markers. Not addressed here; happy to file it separately.

## Checklist

- [x] Branched off `main` as `feat/…` or `fix/…`.
- [x] `ruff check .` passes.
- [x] `python app/telemetry/packet.py` (packet self-test) passes.
- [x] `pytest -q` passes.
- [x] Docs updated where relevant — AGENTS.md (dirty-lap model + a scenario-table row), ARCHITECTURE.md (cross-file invariants: eight mirrored constants plus `impulsive()`), `docs/wiki/Event-Detection.md` (user-facing explanation + a note that older sessions need a Reprocess).
- [ ] For a new detection scenario: added a `tools/simulator.py` flag **and** a matching assertion in `tests/test_scenarios.py`. — **not done deliberately.** This is a *rejection* rule, and a synthetic aero corner is more precisely staged frame-by-frame than through course geometry, so the coverage went into `test_tracker.py` / `test_api.py` with a matching AGENTS.md scenario row. A `--aero` simulator flag would still be nice for full-stack visual checks; say the word and I'll add one.
- [x] Cross-file invariants kept in sync (see ARCHITECTURE.md "Cross-file invariants").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
