### PR TITLE
fix: separate routes that share a start line with a shape term (#53)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,11 +101,16 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 - **`Velocity*` is car-local** like `Acceleration*`: ~`(0, 0, speed)` whatever
   the world direction — useless for heading. `Yaw` IS world-space: the car moves
   along `(sin yaw, cos yaw)` in world X/Z (verified against position deltas).
-- **`DistanceTraveled` is NOT meters** on real circuits: it advances by the same
-  fixed amount every lap of a given route (~2.4–2.5× the true driven length) —
-  a track-position parameter. Perfect for aligning laps and fingerprinting
-  routes; never display it as a length (integrate `Speed` for that). The
-  simulator emits true meters, so this quirk only shows on real-game data.
+- **`DistanceTraveled` is NOT meters** on real circuits: it is *normalized route
+  progress*, running 0 → ~5950 over a full route **whatever the route** — not a
+  per-route constant that scales with length. Swept over ~90 recorded sessions
+  on ~56 distinct routes (2026-07-27): every completed one lands in 5949–5959
+  while the true driven length ranges 2.1–6.9 km, so the ratio to real metres
+  swings 0.86×–2.84×. Partial runs land short of ~5950. Perfect for aligning
+  laps within a route; **useless for telling routes apart** (see the route
+  fingerprint below — this is what issue #53 tripped over), and never display
+  it as a length (integrate `Speed` for that). The simulator emits true
+  meters, so this quirk only shows on real-game data.
 - `DrivetrainType`: 0=FWD 1=RWD 2=AWD. `CarClass`: index into D,C,B,A,S1,S2,R,X
   (R is new in FH6: 901–998 PI; X is 999 only — verified on a real 998 car).
 - Wheel arrays are ordered FL, FR, RL, RR. `TireTemp` is Fahrenheit.
@@ -276,8 +281,17 @@ All the rules exist because some real behavior broke a naive version:
   Test-fixture gotcha: `empty_fields()` zeroes suspension and slip, which
   reads as *airborne* — hand-built test frames must set grounded values or
   every contact spike gets excused (Driver in test_tracker.py does).
-- Routes are fingerprinted (start pos within 80 m + length within 5%) and named
-  once by the user; names apply to every session on the route.
+- Routes are fingerprinted (start pos within 120 m + length within 5% + the
+  lap's bounding-box dimensions within 15%, floor 50 m) and named once by the
+  user; names apply to every session on the route. The **span term carries
+  it**: Horizon courses routinely share a start line and `DistanceTraveled`
+  can't separate them (see above), so start + length alone collapsed different
+  courses onto one row (#53). Spans are stable because they measure ground
+  covered, not the line driven — an excursion or rewind adds distance but
+  barely moves the extents (measured: ≤3.5% across laps of one course, ≥30%
+  between courses off a shared start line). `span_x`/`span_z` NULL = row
+  predates the term; the next matching lap adopts its shape, so reprocessing
+  **both** sessions of an already-merged route is what unpicks it.
 - Sessions with zero completed laps/runs are discarded at close and again at
   startup (`cleanup_sessions`). Every discard logs a `diag:` signal summary
   (duration, race-time range, max LapNumber/CurrentLap, finish seen, gridded,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,8 +51,14 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
 - `laps(id, session_id→sessions CASCADE, lap_number, lap_time, started_t,
   ended_t, start_distance, flags)` — `flags` is CSV: `rewind`, `contact`,
   `cutoff`. `lap_time NULL` = incomplete.
-- `routes(id, name, start_x, start_z, lap_length)` — fingerprint: start within
-  80 m + length within 5 %.
+- `routes(id, name, start_x, start_z, lap_length, span_x, span_z)` —
+  fingerprint: start within 80 m + length within 5 % + bounding-box
+  dimensions within 15 % (floor 50 m). The span term is what separates
+  courses sharing a start line; `lap_length` alone can't, because
+  DistanceTraveled is normalized per route (~5950 for every completed one).
+  `span_x`/`span_z` NULL = row predates the span term; the next matching lap
+  adopts its shape (reprocess both sessions to unpick an already-collapsed
+  route).
 - `car_names(ordinal, name)` — user overrides of the bundled ordinal list.
 - `edits(id, session_id→sessions CASCADE, kind, anchor_t, value, created_at)`
   — manual session edits, applied at read time (raw frames and the recorder's

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,7 +52,7 @@ FH6 ──UDP 9999──▶ listener.py ─▶ packet.py parse ─┬─▶ hub.
   ended_t, start_distance, flags)` — `flags` is CSV: `rewind`, `contact`,
   `cutoff`. `lap_time NULL` = incomplete.
 - `routes(id, name, start_x, start_z, lap_length, span_x, span_z)` —
-  fingerprint: start within 80 m + length within 5 % + bounding-box
+  fingerprint: start within 120 m + length within 5 % + bounding-box
   dimensions within 15 % (floor 50 m). The span term is what separates
   courses sharing a start line; `lap_length` alone can't, because
   DistanceTraveled is normalized per route (~5950 for every completed one).

--- a/app/recorder/laps.py
+++ b/app/recorder/laps.py
@@ -258,6 +258,7 @@ class SessionTracker:
         self._lap_number: int | None = None
         self._lap_start_dist = 0.0
         self._lap_start_pos = (0.0, 0.0)
+        self._lap_bb = [0.0, 0.0, 0.0, 0.0]  # min x, max x, min z, max z
         self._cur_d: list[float] = []   # lap distance trace of the current lap
         self._cur_t: list[float] = []   # matching elapsed lap time
         self._ref_d: list[float] | None = None  # best lap reference
@@ -359,6 +360,10 @@ class SessionTracker:
             self._start_session(t, frame)
         self._buffer.append((t, raw))
         self._frame_count += 1
+        # grows the open lap's bbox before _lap_logic may close that lap and
+        # open the next one (which re-bases the box) - so nothing leaks across
+        # a lap boundary
+        self._bbox_add(frame["pos_x"], frame["pos_z"])
         if frame["race_position"] > 0:
             self._gridded = True
         if any(d > PUDDLE_DEPTH_MIN for d in frame["wheel_in_puddle"]):
@@ -472,6 +477,7 @@ class SessionTracker:
         self._prev_frame_t = None
         self._prev_pos = None
         self._prev_speed = 0.0
+        self._bbox_reset(frame["pos_x"], frame["pos_z"])
         self._lap_distances = []
         self._launch_rt = None
         self._first_rt = frame["current_race_time"]
@@ -542,7 +548,8 @@ class SessionTracker:
                 length = self._prev_dist - self._lap_start_dist
                 if length > 100.0:
                     rid = self.store.match_or_create_route(
-                        self._lap_start_pos[0], self._lap_start_pos[1], length)
+                        self._lap_start_pos[0], self._lap_start_pos[1], length,
+                        *self._lap_extents())
                     self.store.set_session_route(self.session_id, rid)
                     self._route_id = rid
             self.store.complete_lap(self._lap_id, end_t, lap_time, self._flags())
@@ -673,7 +680,8 @@ class SessionTracker:
             length = self._prev_dist - self._lap_start_dist
             if length > 100.0:
                 rid = self.store.match_or_create_route(
-                    self._lap_start_pos[0], self._lap_start_pos[1], length)
+                    self._lap_start_pos[0], self._lap_start_pos[1], length,
+                    *self._lap_extents())
                 self.store.set_session_route(self.session_id, rid)
                 self._route_assigned = True
                 self._route_id = rid
@@ -882,6 +890,7 @@ class SessionTracker:
             self._lap_opened_t = t
             self._lap_start_dist = dist
             self._lap_start_pos = (frame["pos_x"], frame["pos_z"])
+            self._bbox_reset(frame["pos_x"], frame["pos_z"])
             self._cur_d, self._cur_t = [], []
             self._lap_flags = set()  # the lap starts here; earlier flags aren't its
             self._lap_max_elapsed = 0.0
@@ -930,6 +939,7 @@ class SessionTracker:
                 self._lap_opened_t = t
                 self._lap_start_dist = dist
                 self._lap_start_pos = self._wta_anchor
+                self._bbox_reset(*self._wta_anchor)
                 self._cur_d, self._cur_t = [], []
                 self._lap_flags = set()  # pre-launch junk frames must not dirty lap 1
                 self._lap_max_elapsed = 0.0
@@ -993,6 +1003,7 @@ class SessionTracker:
                        stored_ln=self._completed_laps)
         # the reopen used the current frame; rebase it to the crossing itself
         self._lap_start_pos = (bx, bz)
+        self._bbox_reset(bx, bz)
         self._lap_open_rt = brt
 
     def _complete_current_lap(self, t: float, lap_time: float | None, ln: int) -> None:
@@ -1022,6 +1033,7 @@ class SessionTracker:
         self._lap_number = ln
         self._lap_start_dist = dist
         self._lap_start_pos = (frame["pos_x"], frame["pos_z"])
+        self._bbox_reset(frame["pos_x"], frame["pos_z"])
         self._cur_d, self._cur_t = [], []
         self._lap_flags = set()
         self._lap_max_elapsed = 0.0
@@ -1033,12 +1045,35 @@ class SessionTracker:
     def _flags(self) -> str | None:
         return ",".join(sorted(self._lap_flags)) or None
 
+    def _bbox_reset(self, x: float, z: float) -> None:
+        self._lap_bb = [x, x, z, z]
+
+    def _bbox_add(self, x: float, z: float) -> None:
+        b = self._lap_bb
+        if x < b[0]:
+            b[0] = x
+        elif x > b[1]:
+            b[1] = x
+        if z < b[2]:
+            b[2] = z
+        elif z > b[3]:
+            b[3] = z
+
+    def _lap_extents(self) -> tuple[float, float]:
+        """The lap's bounding-box dimensions - the route fingerprint's shape
+        term (see the fingerprint note in store.py). Dimensions rather than
+        corners: they don't move when the car starts from a different grid
+        slot on the same line."""
+        b = self._lap_bb
+        return b[1] - b[0], b[3] - b[2]
+
     def _assign_route(self) -> None:
-        """Fingerprint the just-completed lap's start point + length."""
+        """Fingerprint the just-completed lap's start point, length and shape."""
         if not self._cur_d:
             return
         route_id = self.store.match_or_create_route(
-            self._lap_start_pos[0], self._lap_start_pos[1], self._cur_d[-1])
+            self._lap_start_pos[0], self._lap_start_pos[1], self._cur_d[-1],
+            *self._lap_extents())
         self.store.set_session_route(self.session_id, route_id)
         self._route_assigned = True
         self._route_id = route_id

--- a/app/recorder/store.py
+++ b/app/recorder/store.py
@@ -104,7 +104,14 @@ MIGRATIONS = (
 # course agree to within 3.5%, while different courses off a shared start
 # line differ by 30% or more. The floor keeps small courses (some are only
 # ~270 m across) from tripping on the tolerance alone.
-ROUTE_START_RADIUS_M = 80.0
+# The radius is generous because the span term now backstops it. At 80 m it
+# was splitting single courses in two whenever the grid moved the start a
+# little: in a real database routes 9/24 (81.5 m apart) and 37/59 (102 m)
+# are each one course on two rows. Scanned over every route pair in that
+# database, 120 m merges exactly those two pairs and nothing else - the
+# nearest genuinely different pair sits at 121 m and disagrees on span
+# anyway.
+ROUTE_START_RADIUS_M = 120.0
 ROUTE_LENGTH_TOLERANCE = 0.05
 ROUTE_SPAN_TOLERANCE = 0.15
 ROUTE_SPAN_FLOOR_M = 50.0

--- a/app/recorder/store.py
+++ b/app/recorder/store.py
@@ -82,12 +82,40 @@ MIGRATIONS = (
     # kept=1 exempts a session from the no-completed-laps cleanup
     # (LS_KEEP_DISCARDED captures, reprocessed sessions)
     "ALTER TABLE sessions ADD COLUMN kept INTEGER NOT NULL DEFAULT 0",
+    # the lap's bounding-box dimensions (see the fingerprint note below);
+    # NULL on rows recorded before the span term existed
+    "ALTER TABLE routes ADD COLUMN span_x REAL",
+    "ALTER TABLE routes ADD COLUMN span_z REAL",
 )
 
-# route fingerprint tolerances: same start point within this radius and a
-# lap length within this fraction = same route
+# Route fingerprint: same start point within this radius, a lap length within
+# this fraction, and matching bounding-box dimensions = the same route.
+#
+# The span term carries the fingerprint. Horizon events routinely share a
+# start line, and lap_length can't tell them apart: DistanceTraveled is
+# normalized per route, reading ~5950 at the end of every completed route
+# whatever the true driven distance (3.0 km and 6.9 km courses both report
+# it). Start radius plus length alone therefore collapsed different courses
+# launching from one spot onto a single row.
+#
+# Bounding-box dimensions hold up because they measure the ground covered,
+# not the line driven - an off-track excursion or a rewind adds distance but
+# barely moves the extents. Measured over 100 recorded sessions: laps of one
+# course agree to within 3.5%, while different courses off a shared start
+# line differ by 30% or more. The floor keeps small courses (some are only
+# ~270 m across) from tripping on the tolerance alone.
 ROUTE_START_RADIUS_M = 80.0
 ROUTE_LENGTH_TOLERANCE = 0.05
+ROUTE_SPAN_TOLERANCE = 0.15
+ROUTE_SPAN_FLOOR_M = 50.0
+
+
+def _spans_match(ax: float, az: float, bx: float, bz: float) -> bool:
+    """Do two laps cover the same ground? Both bbox dimensions must agree."""
+    return all(
+        abs(a - b) <= max(ROUTE_SPAN_TOLERANCE * max(a, b), ROUTE_SPAN_FLOOR_M)
+        for a, b in ((ax, bx), (az, bz))
+    )
 
 _SESSION_SELECT = """
 SELECT s.*, r.name AS route_name, cn.name AS car_name_override
@@ -258,15 +286,29 @@ class Store:
         self.db.commit()
 
     def match_or_create_route(self, start_x: float, start_z: float,
-                              lap_length: float) -> int:
-        for rid, rx, rz, rlen in self.db.execute(
-                "SELECT id, start_x, start_z, lap_length FROM routes"):
-            if (math.hypot(start_x - rx, start_z - rz) <= ROUTE_START_RADIUS_M
-                    and abs(lap_length - rlen) <= ROUTE_LENGTH_TOLERANCE * rlen):
+                              lap_length: float, span_x: float,
+                              span_z: float) -> int:
+        for rid, rx, rz, rlen, rsx, rsz in self.db.execute(
+                "SELECT id, start_x, start_z, lap_length, span_x, span_z FROM routes"):
+            if (math.hypot(start_x - rx, start_z - rz) > ROUTE_START_RADIUS_M
+                    or abs(lap_length - rlen) > ROUTE_LENGTH_TOLERANCE * rlen):
+                continue
+            if rsx is None:
+                # recorded before the span term existed: adopt this lap's
+                # shape, so the next course off this start line splits off
+                # instead of collapsing onto the row. Reprocessing the
+                # sessions of an already-collapsed route is what unpicks it.
+                self.db.execute(
+                    "UPDATE routes SET span_x = ?, span_z = ? WHERE id = ?",
+                    (span_x, span_z, rid))
+                self.db.commit()
+                return rid
+            if _spans_match(span_x, span_z, rsx, rsz):
                 return rid
         cur = self.db.execute(
-            "INSERT INTO routes (start_x, start_z, lap_length) VALUES (?, ?, ?)",
-            (start_x, start_z, lap_length),
+            "INSERT INTO routes (start_x, start_z, lap_length, span_x, span_z)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (start_x, start_z, lap_length, span_x, span_z),
         )
         self.db.commit()
         return cur.lastrowid

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -30,6 +30,13 @@ def test_freeroam_then_two_events_wet_same_route(tmp_path):
         assert s["conditions"] == "wet"
     assert ss[0]["route_id"] is not None
     assert ss[0]["route_id"] == ss[1]["route_id"]  # same stadium loop
+    # the fingerprint's shape term, measured by the tracker over a full lap:
+    # the loop is 840 x 240 m (2 x 600 m straights, 120 m radius ends)
+    with store.reader() as conn:
+        route = conn.execute("SELECT * FROM routes WHERE id = ?",
+                             (ss[0]["route_id"],)).fetchone()
+    assert 830 < route["span_x"] < 845
+    assert 232 < route["span_z"] < 245
 
 
 def test_dirty_flags_contact_on_lap2_rewind_on_lap3(tmp_path):

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -312,6 +312,58 @@ def test_impulsive_gate(tmp_path):
     assert not impulsive(t, IMPACT_PEAK - 1, None)
 
 
+def test_route_fingerprint_separates_courses_sharing_a_start_line(tmp_path):
+    """Issue #53: Horizon courses routinely launch from the same spot, and
+    lap_length can't tell them apart - DistanceTraveled is normalized per
+    route, so every completed one reads ~5950 whatever ground it covered.
+    The bbox span term is what separates them. Numbers are the real capture:
+    "Ine Scramble" (session 313) and "Ito Trail" (session 347), 2.5 m apart
+    at the line with lengths within 0.2 m."""
+    store = Store(str(Path(tmp_path) / "telemetry.db"))
+
+    ine = store.match_or_create_route(5890.7, 1811.9, 5951.5, 738.0, 893.7)
+    ito = store.match_or_create_route(5892.9, 1813.2, 5951.7, 1083.1, 2056.0)
+    assert ine != ito
+
+    # ...and further laps of either still land on their own route
+    assert store.match_or_create_route(5891.2, 1812.0, 5953.4, 741.0, 890.2) == ine
+    assert store.match_or_create_route(5893.0, 1813.5, 5950.9, 1080.4, 2060.1) == ito
+    store.close()
+
+
+def test_legacy_route_adopts_a_span_then_splits(tmp_path):
+    """Routes recorded before the span term carry NULL: the next matching lap
+    stamps its shape on the row (name intact), so the other course off that
+    start line splits off instead of collapsing onto it. Reprocessing both
+    sessions of an already-merged route is what unpicks an existing DB."""
+    store = Store(str(Path(tmp_path) / "telemetry.db"))
+    store.db.execute(
+        "INSERT INTO routes (id, name, start_x, start_z, lap_length)"
+        " VALUES (54, 'Ine Scramble', 5890.7, 1811.9, 5951.5)")
+    store.db.commit()
+
+    assert store.match_or_create_route(5890.7, 1811.9, 5951.5, 738.0, 893.7) == 54
+    with store.reader() as conn:
+        row = conn.execute("SELECT * FROM routes WHERE id = 54").fetchone()
+    assert row["name"] == "Ine Scramble"  # the user's rename survives
+    assert (row["span_x"], row["span_z"]) == (738.0, 893.7)
+
+    assert store.match_or_create_route(5892.9, 1813.2, 5951.7, 1083.1, 2056.0) != 54
+    store.close()
+
+
+def test_route_span_tolerance_edges():
+    """Laps of one course drift a few percent (measured: <=3.5% over 100
+    recorded sessions), so the tolerance is wide; the absolute floor covers
+    small courses, where 15 % of a 270 m span is only 40 m."""
+    from app.recorder.store import ROUTE_SPAN_FLOOR_M, _spans_match
+
+    assert _spans_match(1000.0, 1000.0, 1035.0, 970.0)       # ~3.5 % drift
+    assert not _spans_match(1000.0, 1000.0, 1000.0, 1400.0)  # 40 % on one axis
+    assert _spans_match(270.0, 759.0, 270.0 + ROUTE_SPAN_FLOOR_M - 1, 759.0)
+    assert not _spans_match(270.0, 759.0, 270.0 + ROUTE_SPAN_FLOOR_M + 1, 759.0)
+
+
 def test_listener_fallback_keeps_frame_contract(tmp_path):
     """A recorder crash must not shrink the published frame: the extras keep
     the documented shape (session_id/delta/session_best/lap_elapsed/race_mode)."""


### PR DESCRIPTION
## Summary

Two different courses that share a start line collapsed into a single `routes`
row, so they showed one name and renaming either renamed both ("Ine Scramble" /
"Ito Trail"). Closes #53.

The fingerprint was start point + lap length, and **lap length carries no signal
at all**: `DistanceTraveled` is normalized route progress, running 0 → ~5950 over
a full route *whatever the route*. Swept over ~90 recorded sessions on ~56
distinct routes, every completed one lands in 5949–5959 while the true driven
length ranges 2.1–6.9 km. The two colliding sessions drove 3.0 km and 6.9 km and
both reported 5951. That left the 80 m start radius as the entire fingerprint,
and Horizon events routinely launch from the same spot.

**The fix adds the lap's bounding-box dimensions to the fingerprint.**
Dimensions rather than corners, so a different grid slot on the same start line
can't shift them. Spans hold up where length doesn't because they measure the
ground covered, not the line driven — an off-track excursion or a rewind adds
distance but barely moves the extents. Measured over the same 100 sessions:

| | laps of one course | different courses off a shared start line |
|---|---|---|
| bbox span spread | **≤ 3.5 %** | **≥ 30 %** |

Hence the wide 15 % tolerance, with a 50 m floor so courses only a few hundred
metres across don't trip on the fraction alone.

I also evaluated the cheaper-looking option of reusing the existing `lap_length`
column for the *true* integrated path length — no new columns, no new match
logic. It separates both merges, but it fails on stability: path length inflates
7–20 % on any lap with an excursion or rewind, and it would falsely split routes
11 and 46 in a real database. Rejected on the data.

### Migration needs no tooling

`span_x` / `span_z` are NULL on existing rows, and the next matching lap adopts
its shape onto the row (name intact) — so reprocessing an already-merged route's
sessions splits it, using the reprocess path that already exists.

⚠️ **Both** sessions of a merged pair must be reprocessed, oldest first (the
first one keeps the existing route name). Reprocessing only one stamps that
session's shape on the shared row and leaves the other still merged onto it.

### Second commit: 80 m → 120 m start radius

Safe now that the span term backstops it, and it fixes the *opposite* bug — at
80 m a single course splits across two rows whenever the grid moves the start a
little (routes 9/24 at 81.5 m apart with spans 742×1067 vs 744×1072, and 37/59
at 102 m, are each one course on two rows). Scanned over every route pair in a
real database, 120 m merges exactly those two pairs and nothing else; the
nearest genuinely different pair sits at 121 m and disagrees on span anyway.
Kept as its own commit so the two effects can be reverted apart.

### Also found

- **A second collision not in the issue**: route 14 "Airfiel Trail" had sessions
  22/226 (bbox 526×1078) merged with session 351 (2382×2074) — a 4.5× different
  course.
- **AGENTS.md was wrong** about `DistanceTraveled` ("~2.4–2.5× the true driven
  length", which reads as though it scales with length — the ratio actually
  swings 0.86×–2.84×). That misconception is what made a 5 % length tolerance
  look like a real fingerprint term. Corrected in the third commit.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Event-detection change (recorder / `laps.py`)
- [x] Docs only
- [ ] Refactor / chore

## How was it tested?

`pytest -q` — 80 passed. New coverage in `tests/test_tracker.py`:

- `test_route_fingerprint_separates_courses_sharing_a_start_line` — the real
  313/347 capture numbers (2.5 m apart at the line, lengths within 0.2 m) now
  produce two routes, and further laps of either still land on their own.
- `test_legacy_route_adopts_a_span_then_splits` — the NULL-span migration path,
  including that the user's rename survives the adopt.
- `test_route_span_tolerance_edges` — tolerance and floor pinned at their edges.

`tests/test_scenarios.py::test_freeroam_then_two_events_wet_same_route` already
asserted two events land on one route (guards against over-splitting); extended
to assert the tracker measures the simulator's stadium loop as 840 × 240 m,
which covers the bbox plumbing end-to-end.

**Verified against a copy of a real 700 MB database** (migration + reprocess in
the documented order):

```
route 54 → session 313 keeps "Ine Scramble" (span  738 × 894)
           session 347 → new route 75       (span 1083 × 2056)
route 14 → sessions 22, 226 keep "Airfiel Trail" (span  526 × 1078)
           session 351 → new route 76            (span 2382 × 2074)

routes: 74 → 76
```

Lap times byte-identical before and after; no other session's route assignment
moved.

## Checklist

- [x] Branched off `main` as `feat/…` or `fix/…`.
- [x] `ruff check .` passes.
- [x] `python app/telemetry/packet.py` (packet self-test) passes.
- [x] `pytest -q` passes.
- [x] Docs updated where relevant (AGENTS.md detection notes + route
      fingerprint, ARCHITECTURE.md schema).
- [x] For a new detection scenario: no new simulator flag needed — the shape
      term is exercised by the existing same-route scenario (extended with a
      span assertion) plus direct `Store` tests using real capture numbers,
      since the simulator drives one fixed course geometry.
- [x] Cross-file invariants kept in sync (schema documented in
      ARCHITECTURE.md; no API or frontend surface changes — `routes` is only
      ever read via `r.name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
